### PR TITLE
fix missing cmake3 brew formula

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ $ apt-get install cmake3 libssl-dev -y
 
 #### OSX
 ```bash
-$ brew install cmake3
+$ brew install cmake
 ```
 
 ### Running the build


### PR DESCRIPTION
Brew formula for cmake uses 3.15.0 now.  cmake3 formula has been removed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
