### PR TITLE
Use correct keys in browser trie lookups

### DIFF
--- a/lib/browser/mqtt.ts
+++ b/lib/browser/mqtt.ts
@@ -58,7 +58,7 @@ class TopicTrie extends trie.Trie<SubscriptionCallback|undefined> {
         const parts = this.split_key(key);
         let current = this.root;
         let parent = undefined;
-        for (const part in parts) {
+        for (const part of parts) {
             let child = current.children.get(part);
             if (!child) {
                 child = current.children.get('#');

--- a/lib/browser/trie.ts
+++ b/lib/browser/trie.ts
@@ -46,7 +46,7 @@ export class Trie<T> {
         const parts = this.split_key(key);
         let current = this.root;
         let parent = undefined;
-        for (const part in parts) {
+        for (const part of parts) {
             let child = current.children.get(part);
             if (!child) {
                 if (op == TrieOp.Insert) {


### PR DESCRIPTION
Several trie traversals were using array indices and not entry values.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
