### PR TITLE
Linux build does not need to install deps since it runs on the official node image

### DIFF
--- a/continuous-delivery/build-binaries-linux-x64.yml
+++ b/continuous-delivery/build-binaries-linux-x64.yml
@@ -4,7 +4,7 @@ phases:
     commands:
       - mkdir linux-x64
       - cd aws-crt-nodejs
-      - builder build --project=aws-crt-nodejs run_tests=false
+      - builder build --project=aws-crt-nodejs --skip-install run_tests=false
       - cp -r /root/aws-crt-nodejs/dist/bin/native/* ../linux-x64/
 
 artifacts:


### PR DESCRIPTION

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
