### PR TITLE
Remove tsc @awscrt alias preventing browser lib from running

### DIFF
--- a/lib/browser/http.ts
+++ b/lib/browser/http.ts
@@ -8,7 +8,7 @@ export { HttpHeader, HttpProxyOptions, HttpProxyAuthenticationType } from '../co
 import { BufferedEventEmitter } from '../common/event';
 import { CrtError } from './error';
 import axios = require('axios');
-import { ClientBootstrap, InputStream, SocketOptions, TlsConnectionOptions } from '@awscrt/io';
+import { ClientBootstrap, InputStream, SocketOptions, TlsConnectionOptions } from './io';
 
 require('./polyfills')
 


### PR DESCRIPTION
This fixes an issue where the typescript build alias is preserved after compile. Node or a browser is unable to resolve the destination of the alias, and thus throws a module not found error.
I did not find any other occurrences of the aliases used in the ts project. 

This issue is referenced in this comment: https://github.com/awslabs/aws-crt-nodejs/issues/103#issuecomment-662358877
