### PR TITLE
invoke done with err

### DIFF
--- a/lib/common/mqtt.spec.ts
+++ b/lib/common/mqtt.spec.ts
@@ -18,6 +18,7 @@ test('MQTT Connect/Disconnect', async (done) => {
     try {
         aws_opts = await fetch_credentials();
     } catch (err) {
+        done(err);
         return;
     }
 
@@ -56,6 +57,7 @@ test('MQTT Pub/Sub', async (done) => {
     try {
         aws_opts = await fetch_credentials();
     } catch (err) {
+        done(err);
         return;
     }
 
@@ -102,6 +104,7 @@ test('MQTT Will', async (done) => {
     try {
         aws_opts = await fetch_credentials();
     } catch (err) {
+        done(err);
         return;
     }
 
@@ -143,6 +146,7 @@ test('MQTT On Any Publish', async (done) => {
     try {
         aws_opts = await fetch_credentials();
     } catch (err) {
+        done(err);
         return;
     }
 


### PR DESCRIPTION
*Issue #, if available:*
When the test failed, the done should be invoked as error. Or the error info will only be timeout.
*Description of changes:*
Invoke done with error before return when error happens.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
