### PR TITLE
Memory leak fix: releasing reference to payload and topic name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
       - '!master'
 
 env:
-  BUILDER_VERSION: v0.7.0
+  BUILDER_VERSION: v0.7.7
   BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-crt-nodejs

--- a/lib/native/mqtt.ts
+++ b/lib/native/mqtt.ts
@@ -306,15 +306,16 @@ export class MqttClientConnection extends NativeResourceMixin(BufferedEventEmitt
         return new Promise<MqttRequest>((resolve, reject) => {
             reject = this._reject(reject);
 
-            let payload_data = normalize_payload(payload);
             function on_publish(packet_id: number, error_code: number) {
+                payload = "";
+                topic = "";
                 if (error_code == 0) {
                     resolve({ packet_id });
                 } else {
                     reject("Failed to publish: " + io.error_code_to_string(error_code));
                 }
             }
-
+            let payload_data = normalize_payload(payload);
             try {
                 crt_native.mqtt_client_connection_publish(this.native_handle(), topic, payload_data, qos, retain, on_publish);
             } catch (e) {


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*

Ran the pub_sub sample to reproduce the leak mentioned in this issue with results that show garbage collection is now allowed to work: https://github.com/awslabs/aws-crt-nodejs/issues/149
```
[ogudavid@localhost:pub_sub(master)]$ node dist/index.js --endpoint xxxxxxxxxxxx.iot.us-west-2.amazonaws.com -r root.ca.pem -c certificate.pem.crt -k xxxxxxx-private.pem.key -t sdk/test/topic
The script uses approximately 4.69 MB
The script uses approximately 5.58 MB
The script uses approximately 6.41 MB
The script uses approximately 7.42 MB
The script uses approximately 8.21 MB
The script uses approximately 5.29 MB
The script uses approximately 6.34 MB
The script uses approximately 7.29 MB
The script uses approximately 8.34 MB
The script uses approximately 5.3 MB
The script uses approximately 6.31 MB
The script uses approximately 7.15 MB
The script uses approximately 7.94 MB
The script uses approximately 9.05 MB
The script uses approximately 6.07 MB
The script uses approximately 6.92 MB
The script uses approximately 7.91 MB
The script uses approximately 8.82 MB
The script uses approximately 6 MB
The script uses approximately 6.95 MB
The script uses approximately 7.9 MB
The script uses approximately 8.81 MB
The script uses approximately 5.84 MB
The script uses approximately 6.68 MB
The script uses approximately 7.52 MB
The script uses approximately 8.62 MB
The script uses approximately 9.45 MB
The script uses approximately 6.45 MB
The script uses approximately 7.39 MB
The script uses approximately 8.19 MB
The script uses approximately 9.14 MB
The script uses approximately 6.37 MB
The script uses approximately 7.17 MB
The script uses approximately 8.1 MB
The script uses approximately 9.1 MB
```
The script continues with constrained memory usage for a long period of time so it definitely alleviates the clear problem of holding onto the payload.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
