### PR TITLE
Fix browser mqtt.unsubscribe()

### DIFF
--- a/lib/browser/mqtt.ts
+++ b/lib/browser/mqtt.ts
@@ -386,7 +386,11 @@ export class MqttClientConnection extends BufferedEventEmitter {
                     reject(new CrtError(error));
                     return this.on_error(error);
                 }
-                resolve({ packet_id: (packet as mqtt.IUnsubackPacket).messageId });
+                resolve({
+                    packet_id: packet
+                    ? (packet as mqtt.IUnsubackPacket).messageId
+                    : undefined,
+                });
             });
 
         });


### PR DESCRIPTION
Fixes #165.

Handles the expected case of not receiving a packet in unsubscribe callback and passes undefined for the optional `MqttRequest.packer_id`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
