### PR TITLE
Fix crash on websocket reconnect.

### DIFF
--- a/lib/native/binding.d.ts
+++ b/lib/native/binding.d.ts
@@ -118,6 +118,13 @@ export function mqtt_client_connection_new(
     client: NativeHandle,
     on_interrupted?: (error_code: number) => void,
     on_resumed?: (return_code: number, session_present: boolean) => void,
+    tls_ctx?: NativeHandle,
+    will?: { topic: StringLike, payload: String | Object | DataView, qos: number, retain: boolean },
+    username?: StringLike,
+    password?: StringLike,
+    use_websocket?: boolean,
+    proxy_options?: NativeHandle,
+    websocket_handshake_transform?: (request: any, done: (error_code?: number) => void) => void,
 ): NativeHandle;
 
 /** @internal */
@@ -126,18 +133,11 @@ export function mqtt_client_connection_connect(
     client_id: StringLike,
     server_name: StringLike,
     port: number,
-    tls_ctx?: NativeHandle,
     socket_options?: NativeHandle,
     keep_alive_time?: number,
     timeout?: number,
-    will?: { topic: StringLike, payload: String | Object | DataView, qos: number, retain: boolean },
-    username?: StringLike,
-    password?: StringLike,
-    use_websocket?: boolean,
-    proxy_options?: NativeHandle,
     clean_session?: boolean,
     on_connect?: mqtt_on_connect,
-    websocket_handshake_transform?: (request: any, done: (error_code?: number) => void) => void,
 ): void;
 
 /** @internal */

--- a/lib/native/binding.d.ts
+++ b/lib/native/binding.d.ts
@@ -124,7 +124,7 @@ export function mqtt_client_connection_new(
     password?: StringLike,
     use_websocket?: boolean,
     proxy_options?: NativeHandle,
-    websocket_handshake_transform?: (request: any, done: (error_code?: number) => void) => void,
+    websocket_handshake_transform?: (request: HttpRequest, done: (error_code?: number) => void) => void,
 ): NativeHandle;
 
 /** @internal */

--- a/source/module.h
+++ b/source/module.h
@@ -125,6 +125,7 @@ struct aws_napi_context {
  */
 #define AWS_NAPI_ENSURE(env, call)                                                                                     \
     do {                                                                                                               \
+        (void)env;                                                                                                     \
         napi_status status = (call);                                                                                   \
         if (status != napi_ok) {                                                                                       \
             AWS_NAPI_LOGF_FATAL(                                                                                       \

--- a/source/mqtt_client_connection.c
+++ b/source/mqtt_client_connection.c
@@ -703,13 +703,11 @@ cleanup:
     aws_byte_buf_clean_up(&client_id);
     aws_byte_buf_clean_up(&server_name);
 
-    if (!success) {
-        if (on_connect_args) {
-            if (on_connect_args->on_connect) {
-                AWS_NAPI_ENSURE(env, napi_release_threadsafe_function(on_connect_args->on_connect, napi_tsfn_abort));
-            }
-            aws_mem_release(binding->allocator, on_connect_args);
+    if (!success && on_connect_args) {
+        if (on_connect_args->on_connect) {
+            AWS_NAPI_ENSURE(env, napi_release_threadsafe_function(on_connect_args->on_connect, napi_tsfn_abort));
         }
+        aws_mem_release(binding->allocator, on_connect_args);
     }
 
     return NULL;
@@ -957,7 +955,7 @@ static void s_on_suback(
     args->qos = qos;
     args->packet_id = packet_id;
 
-    AWS_NAPI_ENSURE(NULL, aws_napi_queue_threadsafe_function(args->on_suback, args));
+    AWS_NAPI_ENSURE(args->binding->env, aws_napi_queue_threadsafe_function(args->on_suback, args));
 }
 
 /* user data which describes a subscription, passed to aws_mqtt_connection_subscribe */

--- a/source/mqtt_client_connection.c
+++ b/source/mqtt_client_connection.c
@@ -17,25 +17,51 @@
 #include <aws/common/linked_list.h>
 #include <aws/common/mutex.h>
 
+static void s_transform_websocket_call(napi_env env, napi_value transform_websocket, void *context, void *user_data);
+void s_transform_websocket(
+    struct aws_http_message *request,
+    void *user_data,
+    aws_mqtt_transform_websocket_handshake_complete_fn *complete_fn,
+    void *complete_ctx);
+
 struct mqtt_connection_binding {
     struct aws_allocator *allocator;
+    bool use_tls_options;
     struct aws_tls_connection_options tls_options;
-    struct mqtt_nodejs_client *node_client;
     struct aws_mqtt_client_connection *connection;
 
     napi_env env;
-    int last_error_code; /* used to store the error code for dispatching an error */
 
     napi_ref node_external;
     napi_threadsafe_function on_connection_interrupted;
     napi_threadsafe_function on_connection_resumed;
     napi_threadsafe_function on_any_publish;
+    napi_threadsafe_function transform_websocket;
 };
 
 static void s_mqtt_client_connection_finalize(napi_env env, void *finalize_data, void *finalize_hint) {
-    (void)env;
     (void)finalize_hint;
     struct mqtt_connection_binding *binding = finalize_data;
+
+    if (binding->use_tls_options) {
+        aws_tls_connection_options_clean_up(&binding->tls_options);
+    }
+    if (binding->connection) {
+        aws_mqtt_client_connection_release(binding->connection);
+    }
+    if (binding->on_connection_interrupted) {
+        AWS_NAPI_ENSURE(env, napi_release_threadsafe_function(binding->on_connection_interrupted, napi_tsfn_abort));
+    }
+    if (binding->on_connection_resumed) {
+        AWS_NAPI_ENSURE(env, napi_release_threadsafe_function(binding->on_connection_resumed, napi_tsfn_abort));
+    }
+    if (binding->on_any_publish) {
+        AWS_NAPI_ENSURE(env, napi_release_threadsafe_function(binding->on_any_publish, napi_tsfn_abort));
+    }
+    if (binding->transform_websocket) {
+        AWS_NAPI_ENSURE(env, napi_release_threadsafe_function(binding->transform_websocket, napi_tsfn_abort));
+    }
+
     aws_mem_release(binding->allocator, binding);
 }
 
@@ -63,12 +89,8 @@ napi_value aws_napi_mqtt_client_connection_close(napi_env env, napi_callback_inf
     /* no more node interop will be done, free node resources */
     if (binding->node_external) {
         napi_delete_reference(env, binding->node_external);
+        binding->node_external = NULL;
     }
-
-    /* destroy the native connection, which will destroy the subscriptions and
-     * queue destruction of all bound callbacks
-     */
-    aws_mqtt_client_connection_release(binding->connection);
 
     return NULL;
 }
@@ -106,6 +128,9 @@ static void s_on_connection_interrupted(
     (void)connection;
 
     struct mqtt_connection_binding *binding = user_data;
+    if (!binding->on_connection_interrupted) {
+        return;
+    }
 
     struct connection_interrupted_args *args =
         aws_mem_calloc(binding->allocator, 1, sizeof(struct connection_interrupted_args));
@@ -151,6 +176,9 @@ static void s_on_connection_resumed(
     (void)connection;
 
     struct mqtt_connection_binding *binding = user_data;
+    if (!binding->on_connection_resumed) {
+        return;
+    }
 
     struct connection_resumed_args *args =
         aws_mem_calloc(binding->allocator, 1, sizeof(struct connection_resumed_args));
@@ -165,25 +193,50 @@ static void s_on_connection_resumed(
 napi_value aws_napi_mqtt_client_connection_new(napi_env env, napi_callback_info cb_info) {
 
     struct aws_allocator *allocator = aws_napi_get_allocator();
-    napi_value result = NULL;
 
-    struct mqtt_connection_binding *binding = aws_mem_calloc(allocator, 1, sizeof(struct mqtt_connection_binding));
-    AWS_FATAL_ASSERT(binding);
-
-    napi_value node_args[3];
+    napi_value node_args[10];
     size_t num_args = AWS_ARRAY_SIZE(node_args);
     napi_value *arg = &node_args[0];
     AWS_NAPI_CALL(env, napi_get_cb_info(env, cb_info, &num_args, node_args, NULL, NULL), {
         napi_throw_error(env, NULL, "Failed to retreive callback information");
-        goto cleanup;
+        return NULL;
     });
     if (num_args != AWS_ARRAY_SIZE(node_args)) {
-        napi_throw_error(env, NULL, "mqtt_client_connection_new needs exactly 3 arguments");
-        goto cleanup;
+        napi_throw_error(env, NULL, "mqtt_client_connection_new needs exactly 10 arguments");
+        return NULL;
     }
 
-    napi_value node_client = *arg++;
-    AWS_NAPI_CALL(env, napi_get_value_external(env, node_client, (void **)&binding->node_client), {
+    struct mqtt_connection_binding *binding = aws_mem_calloc(allocator, 1, sizeof(struct mqtt_connection_binding));
+    AWS_FATAL_ASSERT(binding);
+    binding->env = env;
+    binding->allocator = allocator;
+
+    napi_value node_external;
+    AWS_NAPI_CALL(env, napi_create_external(env, binding, s_mqtt_client_connection_finalize, NULL, &node_external), {
+        napi_throw_error(env, NULL, "Failed create n-api external");
+        aws_mem_release(allocator, binding);
+        return NULL;
+    });
+
+    /* From hereon, we need to clean up if errors occur.
+     * It's good practice to store long-lived values in the binding, and clean them up from the finalizer.
+     * If this new() function fails partway through, the finalizer will still run and clean them up. */
+
+    napi_value result = NULL;
+
+    /* Allocatations that should not outlive this function */
+    struct aws_byte_buf will_topic;
+    AWS_ZERO_STRUCT(will_topic);
+    struct aws_byte_buf will_payload;
+    AWS_ZERO_STRUCT(will_payload);
+    struct aws_byte_buf username;
+    AWS_ZERO_STRUCT(username);
+    struct aws_byte_buf password;
+    AWS_ZERO_STRUCT(password);
+
+    napi_value node_client_external = *arg++;
+    struct mqtt_nodejs_client *node_client;
+    AWS_NAPI_CALL(env, napi_get_value_external(env, node_client_external, (void **)&node_client), {
         napi_throw_error(env, NULL, "Failed to extract client from external");
         goto cleanup;
     });
@@ -217,25 +270,149 @@ napi_value aws_napi_mqtt_client_connection_new(napi_env env, napi_callback_info 
     }
 
     /* CREATE THE THING */
-    binding->allocator = allocator;
-    binding->connection = aws_mqtt_client_connection_new(binding->node_client->native_client);
+    binding->connection = aws_mqtt_client_connection_new(node_client->native_client);
     if (!binding->connection) {
         napi_throw_error(env, NULL, "Failed create native connection object");
         goto cleanup;
     }
-
-    binding->env = env;
 
     if (binding->on_connection_interrupted || binding->on_connection_resumed) {
         aws_mqtt_client_connection_set_connection_interruption_handlers(
             binding->connection, s_on_connection_interrupted, binding, s_on_connection_resumed, binding);
     }
 
-    napi_value node_external;
-    AWS_NAPI_CALL(env, napi_create_external(env, binding, s_mqtt_client_connection_finalize, NULL, &node_external), {
-        napi_throw_error(env, NULL, "Failed create n-api external");
-        goto cleanup;
-    });
+    napi_value node_tls = *arg++;
+    if (!aws_napi_is_null_or_undefined(env, node_tls)) {
+        struct aws_tls_ctx *tls_ctx;
+        AWS_NAPI_CALL(env, napi_get_value_external(env, node_tls, (void **)&tls_ctx), {
+            napi_throw_error(env, NULL, "Failed to extract tls_ctx from external");
+            goto cleanup;
+        });
+
+        aws_tls_connection_options_init_from_ctx(&binding->tls_options, tls_ctx);
+        binding->use_tls_options = true;
+    }
+
+    napi_value node_will = *arg++;
+    if (!aws_napi_is_null_or_undefined(env, node_will)) {
+        napi_value node_topic = NULL;
+        AWS_NAPI_CALL(env, napi_get_named_property(env, node_will, "topic", &node_topic), {
+            napi_throw_type_error(env, NULL, "will must contain a topic string");
+            goto cleanup;
+        });
+        AWS_NAPI_CALL(env, aws_byte_buf_init_from_napi(&will_topic, env, node_topic), {
+            aws_napi_throw_last_error(env);
+            goto cleanup;
+        });
+        napi_value node_payload;
+        AWS_NAPI_CALL(env, napi_get_named_property(env, node_will, "payload", &node_payload), {
+            napi_throw_type_error(env, NULL, "will must contain a payload DataView");
+            goto cleanup;
+        });
+        AWS_NAPI_CALL(env, aws_byte_buf_init_from_napi(&will_payload, env, node_payload), {
+            aws_napi_throw_last_error(env);
+            goto cleanup;
+        });
+        napi_value node_qos;
+        AWS_NAPI_CALL(env, napi_get_named_property(env, node_will, "qos", &node_qos), {
+            napi_throw_type_error(env, NULL, "will must contain a qos member");
+            goto cleanup;
+        });
+        enum aws_mqtt_qos will_qos;
+        AWS_NAPI_CALL(env, napi_get_value_int32(env, node_qos, (int32_t *)&will_qos), {
+            napi_throw_type_error(env, NULL, "will.qos must be a number");
+            goto cleanup;
+        });
+        napi_value node_retain;
+        AWS_NAPI_CALL(env, napi_get_named_property(env, node_will, "retain", &node_retain), {
+            napi_throw_type_error(env, NULL, "will must contain a retain member");
+            goto cleanup;
+        });
+        bool will_retain;
+        AWS_NAPI_CALL(env, napi_get_value_bool(env, node_retain, &will_retain), {
+            napi_throw_type_error(env, NULL, "will.retain must be a boolean");
+            goto cleanup;
+        });
+
+        struct aws_byte_cursor topic_cur = aws_byte_cursor_from_buf(&will_topic);
+        struct aws_byte_cursor payload_cur = aws_byte_cursor_from_buf(&will_payload);
+        if (aws_mqtt_client_connection_set_will(binding->connection, &topic_cur, will_qos, will_retain, &payload_cur)) {
+            aws_napi_throw_last_error(env);
+            goto cleanup;
+        }
+    }
+
+    napi_value node_username = *arg++;
+    if (!aws_napi_is_null_or_undefined(env, node_username)) {
+        AWS_NAPI_CALL(env, aws_byte_buf_init_from_napi(&username, env, node_username), {
+            napi_throw_type_error(env, NULL, "username must be a String");
+            goto cleanup;
+        });
+    }
+
+    napi_value node_password = *arg++;
+    if (!aws_napi_is_null_or_undefined(env, node_password)) {
+        AWS_NAPI_CALL(env, aws_byte_buf_init_from_napi(&password, env, node_password), {
+            napi_throw_type_error(env, NULL, "password must be a String");
+            goto cleanup;
+        });
+    }
+
+    if (username.buffer || password.buffer) {
+        struct aws_byte_cursor username_cur = aws_byte_cursor_from_buf(&username);
+        struct aws_byte_cursor password_cur = aws_byte_cursor_from_buf(&password);
+        if (aws_mqtt_client_connection_set_login(binding->connection, &username_cur, &password_cur)) {
+            aws_napi_throw_last_error(env);
+            goto cleanup;
+        }
+    }
+
+    napi_value node_use_websocket = *arg++;
+    bool use_websocket = false;
+    if (!aws_napi_is_null_or_undefined(env, node_use_websocket)) {
+        AWS_NAPI_CALL(env, napi_get_value_bool(env, node_use_websocket, &use_websocket), {
+            napi_throw_type_error(env, NULL, "use_websocket must be a boolean");
+            goto cleanup;
+        });
+    }
+
+    napi_value node_proxy_options = *arg++;
+    struct aws_http_proxy_options *proxy_options = NULL;
+    if (!aws_napi_is_null_or_undefined(env, node_proxy_options)) {
+        struct http_proxy_options_binding *proxy_binding = NULL;
+        AWS_NAPI_CALL(env, napi_get_value_external(env, node_proxy_options, (void **)&proxy_binding), {
+            napi_throw_type_error(env, NULL, "proxy_options must be an external");
+            goto cleanup;
+        });
+        /* proxy_options are copied internally, no need to go nuts on copies */
+        proxy_options = aws_napi_get_http_proxy_options(proxy_binding);
+        aws_mqtt_client_connection_set_websocket_proxy_options(binding->connection, proxy_options);
+    }
+
+    napi_value node_transform_websocket = *arg++;
+    if (use_websocket) {
+        if (!aws_napi_is_null_or_undefined(env, node_transform_websocket)) {
+            AWS_NAPI_CALL(
+                env,
+                aws_napi_create_threadsafe_function(
+                    env,
+                    node_transform_websocket,
+                    "aws_mqtt_client_connection_transform_websocket",
+                    s_transform_websocket_call,
+                    binding,
+                    &binding->transform_websocket),
+                {
+                    napi_throw_error(env, NULL, "Failed to bind transform_websocket callback");
+                    goto cleanup;
+                });
+            aws_mqtt_client_connection_use_websockets(binding->connection, s_transform_websocket, binding, NULL, NULL);
+        } else {
+            aws_mqtt_client_connection_use_websockets(binding->connection, NULL, NULL, NULL, NULL);
+        }
+    }
+
+    /* napi_create_reference() must be the last thing called by this function.
+     * Once this succeeds, the external will not be cleaned up automatically */
     AWS_NAPI_CALL(env, napi_create_reference(env, node_external, 1, &binding->node_external), {
         napi_throw_error(env, NULL, "Failed to reference node external");
         goto cleanup;
@@ -244,21 +421,10 @@ napi_value aws_napi_mqtt_client_connection_new(napi_env env, napi_callback_info 
     result = node_external;
 
 cleanup:
-    if (!result) {
-        if (binding->connection) {
-            aws_mqtt_client_connection_release(binding->connection);
-        }
-
-        if (binding->on_connection_interrupted) {
-            AWS_NAPI_ENSURE(env, napi_release_threadsafe_function(binding->on_connection_interrupted, napi_tsfn_abort));
-        }
-        if (binding->on_connection_resumed) {
-            AWS_NAPI_ENSURE(env, napi_release_threadsafe_function(binding->on_connection_resumed, napi_tsfn_abort));
-        }
-
-        aws_mem_release(allocator, binding);
-    }
-
+    aws_byte_buf_clean_up(&will_topic);
+    aws_byte_buf_clean_up(&will_payload);
+    aws_byte_buf_clean_up(&username);
+    aws_byte_buf_clean_up(&password);
     return result;
 }
 
@@ -316,7 +482,6 @@ static void s_on_connected(
 
 struct transform_websocket_args {
     struct mqtt_connection_binding *binding;
-    napi_threadsafe_function transform_websocket;
 
     struct aws_http_message *request;
 
@@ -381,7 +546,7 @@ static void s_transform_websocket_call(napi_env env, napi_value transform_websoc
         AWS_NAPI_ENSURE(
             env,
             aws_napi_dispatch_threadsafe_function(
-                env, args->transform_websocket, NULL, transform_websocket, num_params, params));
+                env, args->binding->transform_websocket, NULL, transform_websocket, num_params, params));
     }
 }
 
@@ -390,25 +555,25 @@ void s_transform_websocket(
     void *user_data,
     aws_mqtt_transform_websocket_handshake_complete_fn *complete_fn,
     void *complete_ctx) {
-    struct transform_websocket_args *args = user_data;
 
-    if (!args->transform_websocket) {
-        aws_mem_release(args->binding->allocator, args);
-        return;
-    }
+    struct mqtt_connection_binding *binding = user_data;
 
+    struct transform_websocket_args *args =
+        aws_mem_calloc(binding->allocator, 1, sizeof(struct transform_websocket_args));
+    AWS_FATAL_ASSERT(args);
+
+    args->binding = binding;
     args->request = request;
     args->complete_fn = complete_fn;
     args->complete_ctx = complete_ctx;
 
-    AWS_NAPI_ENSURE(NULL, aws_napi_queue_threadsafe_function(args->transform_websocket, args));
+    AWS_NAPI_ENSURE(NULL, aws_napi_queue_threadsafe_function(binding->transform_websocket, args));
 }
 
 napi_value aws_napi_mqtt_client_connection_connect(napi_env env, napi_callback_info cb_info) {
 
-    napi_value result = NULL;
+    bool success = false;
 
-    struct aws_tls_ctx *tls_ctx = NULL;
     struct aws_socket_options *socket_options = NULL;
     struct mqtt_connection_binding *binding = NULL;
 
@@ -416,16 +581,9 @@ napi_value aws_napi_mqtt_client_connection_connect(napi_env env, napi_callback_i
     AWS_ZERO_STRUCT(client_id);
     struct aws_byte_buf server_name;
     AWS_ZERO_STRUCT(server_name);
-    struct aws_byte_buf username;
-    AWS_ZERO_STRUCT(username);
-    struct aws_byte_buf password;
-    AWS_ZERO_STRUCT(password);
-    struct aws_byte_buf will_topic;
-    AWS_ZERO_STRUCT(will_topic);
-    struct aws_byte_buf will_payload;
-    AWS_ZERO_STRUCT(will_payload);
+    struct connect_args *on_connect_args = NULL;
 
-    napi_value node_args[16];
+    napi_value node_args[9];
     size_t num_args = AWS_ARRAY_SIZE(node_args);
     napi_value *arg = &node_args[0];
     AWS_NAPI_CALL(env, napi_get_cb_info(env, cb_info, &num_args, node_args, NULL, NULL), {
@@ -433,7 +591,7 @@ napi_value aws_napi_mqtt_client_connection_connect(napi_env env, napi_callback_i
         goto cleanup;
     });
     if (num_args != AWS_ARRAY_SIZE(node_args)) {
-        napi_throw_error(env, NULL, "mqtt_client_connection_connect needs exactly 16 arguments");
+        napi_throw_error(env, NULL, "mqtt_client_connection_connect needs exactly 9 arguments");
         goto cleanup;
     }
 
@@ -462,14 +620,6 @@ napi_value aws_napi_mqtt_client_connection_connect(napi_env env, napi_callback_i
         goto cleanup;
     });
 
-    napi_value node_tls = *arg++;
-    if (!aws_napi_is_null_or_undefined(env, node_tls)) {
-        AWS_NAPI_CALL(env, napi_get_value_external(env, node_tls, (void **)&tls_ctx), {
-            napi_throw_error(env, NULL, "Failed to extract tls_ctx from external");
-            goto cleanup;
-        });
-    }
-
     napi_value node_socket_options = *arg++;
     if (!aws_napi_is_null_or_undefined(env, node_socket_options)) {
         AWS_NAPI_CALL(env, napi_get_value_external(env, node_socket_options, (void **)&socket_options), {
@@ -496,85 +646,6 @@ napi_value aws_napi_mqtt_client_connection_connect(napi_env env, napi_callback_i
         });
     }
 
-    napi_value node_will = *arg++;
-    enum aws_mqtt_qos will_qos = AWS_MQTT_QOS_AT_LEAST_ONCE;
-    bool will_retain = false;
-    if (!aws_napi_is_null_or_undefined(env, node_will)) {
-        napi_value node_topic = NULL;
-        AWS_NAPI_CALL(env, napi_get_named_property(env, node_will, "topic", &node_topic), {
-            napi_throw_type_error(env, NULL, "will must contain a topic string");
-            goto cleanup;
-        });
-        AWS_NAPI_CALL(env, aws_byte_buf_init_from_napi(&will_topic, env, node_topic), {
-            aws_napi_throw_last_error(env);
-            goto cleanup;
-        });
-        napi_value node_payload;
-        AWS_NAPI_CALL(env, napi_get_named_property(env, node_will, "payload", &node_payload), {
-            napi_throw_type_error(env, NULL, "will must contain a payload DataView");
-            goto cleanup;
-        });
-        AWS_NAPI_CALL(env, aws_byte_buf_init_from_napi(&will_payload, env, node_payload), {
-            aws_napi_throw_last_error(env);
-            goto cleanup;
-        });
-        napi_value node_qos;
-        AWS_NAPI_CALL(env, napi_get_named_property(env, node_will, "qos", &node_qos), {
-            napi_throw_type_error(env, NULL, "will must contain a qos member");
-            goto cleanup;
-        });
-        AWS_NAPI_CALL(env, napi_get_value_int32(env, node_qos, (int32_t *)&will_qos), {
-            napi_throw_type_error(env, NULL, "will.qos must be a number");
-            goto cleanup;
-        });
-        napi_value node_retain;
-        AWS_NAPI_CALL(env, napi_get_named_property(env, node_will, "retain", &node_retain), {
-            napi_throw_type_error(env, NULL, "will must contain a retain member");
-            goto cleanup;
-        });
-        AWS_NAPI_CALL(env, napi_get_value_bool(env, node_retain, &will_retain), {
-            napi_throw_type_error(env, NULL, "will.retain must be a boolean");
-            goto cleanup;
-        });
-    }
-
-    napi_value node_username = *arg++;
-    if (!aws_napi_is_null_or_undefined(env, node_username)) {
-        AWS_NAPI_CALL(env, aws_byte_buf_init_from_napi(&username, env, node_username), {
-            napi_throw_type_error(env, NULL, "username must be a String");
-            goto cleanup;
-        });
-    }
-
-    napi_value node_password = *arg++;
-    if (!aws_napi_is_null_or_undefined(env, node_password)) {
-        AWS_NAPI_CALL(env, aws_byte_buf_init_from_napi(&password, env, node_password), {
-            napi_throw_type_error(env, NULL, "password must be a String");
-            goto cleanup;
-        });
-    }
-
-    napi_value node_use_websocket = *arg++;
-    bool use_websocket = false;
-    if (!aws_napi_is_null_or_undefined(env, node_use_websocket)) {
-        AWS_NAPI_CALL(env, napi_get_value_bool(env, node_use_websocket, &use_websocket), {
-            napi_throw_type_error(env, NULL, "use_websocket must be a boolean");
-            goto cleanup;
-        });
-    }
-
-    napi_value node_proxy_options = *arg++;
-    struct aws_http_proxy_options *proxy_options = NULL;
-    if (!aws_napi_is_null_or_undefined(env, node_proxy_options)) {
-        struct http_proxy_options_binding *proxy_binding = NULL;
-        AWS_NAPI_CALL(env, napi_get_value_external(env, node_proxy_options, (void **)&proxy_binding), {
-            napi_throw_type_error(env, NULL, "proxy_options must be an external");
-            goto cleanup;
-        });
-        /* proxy_options are copied internally, no need to go nuts on copies */
-        proxy_options = aws_napi_get_http_proxy_options(proxy_binding);
-    }
-
     napi_value node_clean_session = *arg++;
     bool clean_session = false;
     if (!aws_napi_is_null_or_undefined(env, node_clean_session)) {
@@ -585,7 +656,6 @@ napi_value aws_napi_mqtt_client_connection_connect(napi_env env, napi_callback_i
     }
 
     napi_value node_on_connect = *arg++;
-    struct connect_args *on_connect_args = NULL;
     if (!aws_napi_is_null_or_undefined(env, node_on_connect)) {
 
         on_connect_args = aws_mem_calloc(binding->allocator, 1, sizeof(struct connect_args));
@@ -606,10 +676,6 @@ napi_value aws_napi_mqtt_client_connection_connect(napi_env env, napi_callback_i
             });
     }
 
-    if (tls_ctx) {
-        aws_tls_connection_options_init_from_ctx(&binding->tls_options, tls_ctx);
-    }
-
     struct aws_byte_cursor client_id_cur = aws_byte_cursor_from_buf(&client_id);
     struct aws_byte_cursor server_name_cur = aws_byte_cursor_from_buf(&server_name);
 
@@ -623,72 +689,30 @@ napi_value aws_napi_mqtt_client_connection_connect(napi_env env, napi_callback_i
     options.port = (uint16_t)port_number;
 
     options.socket_options = socket_options;
-    options.tls_options = tls_ctx ? &binding->tls_options : NULL;
+    options.tls_options = binding->use_tls_options ? &binding->tls_options : NULL;
     options.user_data = on_connect_args; /* on_connect user_data */
-
-    if (will_topic.buffer) {
-        struct aws_byte_cursor topic_cur = aws_byte_cursor_from_buf(&will_topic);
-        struct aws_byte_cursor payload_cur = aws_byte_cursor_from_buf(&will_payload);
-        if (aws_mqtt_client_connection_set_will(binding->connection, &topic_cur, will_qos, will_retain, &payload_cur)) {
-            aws_napi_throw_last_error(env);
-            goto cleanup;
-        }
-    }
-
-    if (username.buffer || password.buffer) {
-        struct aws_byte_cursor username_cur = aws_byte_cursor_from_buf(&username);
-        struct aws_byte_cursor password_cur = aws_byte_cursor_from_buf(&password);
-        if (aws_mqtt_client_connection_set_login(binding->connection, &username_cur, &password_cur)) {
-            aws_napi_throw_last_error(env);
-            goto cleanup;
-        }
-    }
-
-    napi_value node_transform_websocket = *arg++;
-    if (use_websocket) {
-
-        struct transform_websocket_args *ws_tf_args =
-            aws_mem_calloc(binding->allocator, 1, sizeof(struct transform_websocket_args));
-        AWS_FATAL_ASSERT(ws_tf_args);
-        ws_tf_args->binding = binding;
-
-        if (!aws_napi_is_null_or_undefined(env, node_transform_websocket)) {
-            AWS_NAPI_CALL(
-                env,
-                aws_napi_create_threadsafe_function(
-                    env,
-                    node_transform_websocket,
-                    "aws_mqtt_client_connection_transform_websocket",
-                    s_transform_websocket_call,
-                    binding,
-                    &ws_tf_args->transform_websocket),
-                {
-                    napi_throw_error(env, NULL, "Failed to bind transform_websocket callback");
-                    goto cleanup;
-                });
-        }
-
-        aws_mqtt_client_connection_use_websockets(binding->connection, s_transform_websocket, ws_tf_args, NULL, NULL);
-
-        if (proxy_options) {
-            aws_mqtt_client_connection_set_websocket_proxy_options(binding->connection, proxy_options);
-        }
-    }
 
     if (aws_mqtt_client_connection_connect(binding->connection, &options)) {
         aws_napi_throw_last_error(env);
         goto cleanup;
     }
 
+    success = true;
+
 cleanup:
     aws_byte_buf_clean_up(&client_id);
     aws_byte_buf_clean_up(&server_name);
-    aws_byte_buf_clean_up_secure(&username);
-    aws_byte_buf_clean_up_secure(&password);
-    aws_byte_buf_clean_up(&will_topic);
-    aws_byte_buf_clean_up(&will_payload);
 
-    return result;
+    if (!success) {
+        if (on_connect_args) {
+            if (on_connect_args->on_connect) {
+                AWS_NAPI_ENSURE(env, napi_release_threadsafe_function(on_connect_args->on_connect, napi_tsfn_abort));
+            }
+            aws_mem_release(binding->allocator, on_connect_args);
+        }
+    }
+
+    return NULL;
 }
 
 /*******************************************************************************
@@ -933,7 +957,7 @@ static void s_on_suback(
     args->qos = qos;
     args->packet_id = packet_id;
 
-    AWS_NAPI_ENSURE(env, aws_napi_queue_threadsafe_function(args->on_suback, args));
+    AWS_NAPI_ENSURE(NULL, aws_napi_queue_threadsafe_function(args->on_suback, args));
 }
 
 /* user data which describes a subscription, passed to aws_mqtt_connection_subscribe */


### PR DESCRIPTION
Bug was that `transform_websocket_args` pointer was being destroyed after 1st use, but pointer was re-used for any future reconnects, leading to access violoations. Solution is to create a new `transform_websocket_args` each time a transformation occurs.

Also moved a LOT of logic into the internal MQTT new() call, instead of the internal connect() call. I moved things that only needed to be set once (ex: websocket transform fn). I also added a bunch of cleanup calls to the finalize() function, seems like we were leaking JS resources before... but this is my first time really digging into this code so would love another set of eyeballs on this

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
