### PR TITLE
Deliver MQTT payload as ArrayBuffer.

### DIFF
--- a/lib/browser/mqtt.ts
+++ b/lib/browser/mqtt.ts
@@ -265,16 +265,14 @@ export class MqttClientConnection extends BufferedEventEmitter {
     }
 
     private on_message = (topic: string, payload: Buffer, packet: mqtt.IPublishPacket) => {
-        // We want to use built-in JS types.
-        // Though node's Buffer type extends Uint8Array, it has subtle API incompatibilities.
-        const u8 = new Uint8Array(payload);
-        // TODO: figure out why `new Uint8Array(payload.buffer, payload.byteOffset, payload.length)` leads to CI failures
+        // pass payload as ArrayBuffer
+        const array_buffer = payload.buffer.slice(payload.byteOffset, payload.byteOffset + payload.byteLength)
 
         const callback = this.subscriptions.find(topic);
         if (callback) {
-            callback(topic, u8, packet.dup, packet.qos, packet.retain);
+            callback(topic, array_buffer, packet.dup, packet.qos, packet.retain);
         }
-        this.emit('message', topic, u8, packet.dup, packet.qos, packet.retain);
+        this.emit('message', topic, array_buffer, packet.dup, packet.qos, packet.retain);
     }
 
     /**

--- a/lib/common/mqtt.spec.ts
+++ b/lib/common/mqtt.spec.ts
@@ -77,7 +77,7 @@ test('MQTT Pub/Sub', async (done) => {
             const test_payload = 'NOTICE ME';
             const sub = connection.subscribe(test_topic, QoS.AtLeastOnce, async (topic, payload, dup, qos, retain) => {
                 expect(topic).toEqual(test_topic);
-                const payload_str = (new TextDecoder()).decode(payload);
+                const payload_str = (new TextDecoder()).decode(new Uint8Array(payload));
                 expect(payload_str).toEqual(test_payload);
                 expect(qos).toEqual(QoS.AtLeastOnce);
                 expect(retain).toBeFalsy();
@@ -168,7 +168,7 @@ test('MQTT On Any Publish', async (done) => {
         connection.on('message', async (topic, payload, dup, qos, retain) => {
             expect(topic).toEqual(test_topic);
             expect(payload).toBeDefined();
-            const payload_str = (new TextDecoder()).decode(payload);
+            const payload_str = (new TextDecoder()).decode(new Uint8Array(payload));
             expect(payload_str).toEqual(test_payload);
             expect(qos).toEqual(QoS.AtLeastOnce);
             expect(retain).toBeFalsy();

--- a/lib/common/mqtt.ts
+++ b/lib/common/mqtt.ts
@@ -59,7 +59,7 @@ export type Payload = String | Object | DataView;
  * @module aws-crt
  * @category MQTT
  */
-export type OnMessageCallback = (topic: string, payload: Uint8Array, dup: boolean, qos: QoS, retain: boolean) => void;
+export type OnMessageCallback = (topic: string, payload: ArrayBuffer, dup: boolean, qos: QoS, retain: boolean) => void;
 
 /**
  * Every request sent returns an MqttRequest

--- a/lib/native/binding.d.ts
+++ b/lib/native/binding.d.ts
@@ -6,7 +6,7 @@
 import { InputStream } from "./io";
 import { AwsSigningAlgorithm, AwsSignatureType, AwsSignedBodyValue, AwsSignedBodyHeaderType } from "./auth";
 import { HttpHeader, HttpHeaders as CommonHttpHeaders } from "../common/http";
-import { QoS } from "lib/common/mqtt";
+import { OnMessageCallback, QoS } from "lib/common/mqtt";
 
 /**
  * Type used to store pointers to CRT native resources
@@ -154,22 +154,20 @@ export function mqtt_client_connection_publish(
     on_publish?: (packet_id: number, error_code: number) => void,
 ): void;
 
-/** @internal */
-export type OnMessageCallbackNative = (topic: string, payload: ArrayBuffer, dup: boolean, qos: QoS, retain: boolean) => void;
 
 /** @internal */
 export function mqtt_client_connection_subscribe(
     connection: NativeHandle,
     topic: StringLike,
     qos: number,
-    on_publish?: OnMessageCallbackNative,
+    on_publish?: OnMessageCallback,
     on_suback?: (packet_id: number, topic: string, qos: QoS, error_code: number) => void,
 ): void;
 
 /** @internal */
 export function mqtt_client_connection_on_message(
     connection: NativeHandle,
-    on_publish?: OnMessageCallbackNative
+    on_publish?: OnMessageCallback
 ): void;
 
 /** @internal */

--- a/lib/native/mqtt.ts
+++ b/lib/native/mqtt.ts
@@ -348,13 +348,6 @@ export class MqttClientConnection extends NativeResourceMixin(BufferedEventEmitt
         return new Promise<MqttSubscribeRequest>((resolve, reject) => {
             reject = this._reject(reject);
 
-            let on_message_native = undefined;
-            if (on_message) {
-                on_message_native = function(topic: string, payload: ArrayBuffer, dup: boolean, qos: QoS, retain: boolean) {
-                    on_message(topic, new Uint8Array(payload), dup, qos, retain);
-                }
-            }
-
             function on_suback(packet_id: number, topic: string, qos: QoS, error_code: number) {
                 if (error_code == 0) {
                     resolve({ packet_id, topic, qos, error_code });
@@ -364,7 +357,7 @@ export class MqttClientConnection extends NativeResourceMixin(BufferedEventEmitt
             }
 
             try {
-                crt_native.mqtt_client_connection_subscribe(this.native_handle(), topic, qos, on_message_native, on_suback);
+                crt_native.mqtt_client_connection_subscribe(this.native_handle(), topic, qos, on_message, on_suback);
             } catch (e) {
                 reject(e);
             }
@@ -444,6 +437,6 @@ export class MqttClientConnection extends NativeResourceMixin(BufferedEventEmitt
     }
 
     private _on_any_publish(topic: string, payload: ArrayBuffer, dup: boolean, qos: QoS, retain: boolean) {
-        this.emit('message', topic, new Uint8Array(payload), dup, qos, retain);
+        this.emit('message', topic, payload, dup, qos, retain);
     }
 }

--- a/samples/browser/pub_sub/index.ts
+++ b/samples/browser/pub_sub/index.ts
@@ -69,10 +69,10 @@ async function main() {
     fetch_credentials()
         .then(connect_websocket)
         .then((connection) => {
-            connection.subscribe('/test/me/senpai', mqtt.QoS.AtLeastOnce, (topic, payload) => {
+            connection.subscribe('/test/me/senpai', mqtt.QoS.AtLeastOnce, (topic, payload, dup, qos, retain) => {
                 const decoder = new TextDecoder('utf8');
-                let message = decoder.decode(payload);
-                log(`Message recieved: topic=${topic} message=${message}`);
+                let message = decoder.decode(new Uint8Array(payload));
+                log(`Message received: topic=${topic} message=${message}`);
                 connection.disconnect();
             })
             .then((subscription) => {


### PR DESCRIPTION
In PR https://github.com/awslabs/aws-crt-nodejs/pull/172 I made an API-breaking change, switching the MQTT payload from ArrayBuffer to Uint8Array. I don't know what I was thinking. API breakage is bad. This puts it back the way it was (and fixes bugs where we weren't passing the correct type).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
