### PR TITLE
fix the async call crash

### DIFF
--- a/builder.json
+++ b/builder.json
@@ -90,6 +90,17 @@
             "npm",
             "run",
 	    "test:native"
+        ],
+        [
+            "npm",
+            "install",
+            "{project_dir}/samples/node/elasticurl/"
+        ],
+        [
+            "{python}",
+            "{project_dir}/crt/aws-c-http/integration-testing/http_client_test.py",
+            "node",
+            "{project_dir}/samples/node/elasticurl/dist/elasticurl.js"
         ]
     ]
 }

--- a/samples/node/elasticurl/elasticurl.ts
+++ b/samples/node/elasticurl/elasticurl.ts
@@ -18,125 +18,125 @@ yargs.command('*', false, (yargs: any) => {
         type: 'URL',
         default: new URL(url)
     })
-    .option('cacert', {
-        description: 'FILE: path to a CA certficate file.',
-        type: 'string'
-    })
-    .option('capath', {
-        description: 'PATH: path to a directory containing CA files.',
-        type: 'string'
-    })
-    .option('cert', {
-        description: 'FILE: path to a PEM encoded certificate to use with mTLS',
-        type: 'string'
-    })
-    .option('key', {
-        description: 'FILE: Path to a PEM encoded private key that matches cert.',
-        type: 'string'
-    })
-    .option('connect_timeout', {
-        description: 'INT: time in milliseconds to wait for a connection.',
-        type: 'number',
-        default: 3000,
-    })
-    .option('header', {
-        alias: 'H',
-        description: 'LINE: line to send as a header in format [header-key]: [header-value]\n',
-        type: 'array'
-    })
-    .option('data', {
-        alias: 'd',
-        description: 'STRING: Data to POST or PUT.',
-        type: 'string',
-        default: undefined,
-        coerce: (value: string) => {
-            if (value) {
-                let stream = new PassThrough();
-                stream.write(value);
-                stream.end();
-                return stream;
+        .option('cacert', {
+            description: 'FILE: path to a CA certficate file.',
+            type: 'string'
+        })
+        .option('capath', {
+            description: 'PATH: path to a directory containing CA files.',
+            type: 'string'
+        })
+        .option('cert', {
+            description: 'FILE: path to a PEM encoded certificate to use with mTLS',
+            type: 'string'
+        })
+        .option('key', {
+            description: 'FILE: Path to a PEM encoded private key that matches cert.',
+            type: 'string'
+        })
+        .option('connect_timeout', {
+            description: 'INT: time in milliseconds to wait for a connection.',
+            type: 'number',
+            default: 3000,
+        })
+        .option('header', {
+            alias: 'H',
+            description: 'LINE: line to send as a header in format [header-key]: [header-value]\n',
+            type: 'array'
+        })
+        .option('data', {
+            alias: 'd',
+            description: 'STRING: Data to POST or PUT.',
+            type: 'string',
+            default: undefined,
+            coerce: (value: string) => {
+                if (value) {
+                    let stream = new PassThrough();
+                    stream.write(value);
+                    stream.end();
+                    return stream;
+                }
+                return value;
             }
-            return value;
-        }
-    })
-    .option('data_file', {
-        description: 'FILE: File to read from file and POST or PUT.',
-        type: 'string'
-    })
-    .option('method', {
-        alias: 'M',
-        description: 'STRING: Http Method verb to use for the request.',
-        choices: ['GET', 'POST', 'PUT', 'DELETE', 'HEAD'],
-        default: 'GET'
-    })
-    .option('get', {
-        alias: 'G',
-        description: 'uses GET for the verb'
-    })
-    .option('post', {
-        alias: 'P',
-        description: 'uses POST for the verb'
-    })
-    .option('head', {
-        alias: 'I',
-        description: 'uses HEAD for the verb'
-    })
-    .option('include', {
-        alias: 'i',
-        description: 'Includes headers in output',
-        type: 'boolean',
-        default: false
-    })
-    .option('insecure', {
-        alias: 'k',
-        description: 'Turns off X.509 validation',
-        type: 'boolean',
-        default: false
-    })
-    .option('output', {
-        alias: 'o',
-        description: 'FILE: dumps content-body to FILE instead of stdout.',
-        type: 'string',
-        default: process.stdout,
-        coerce: (value: string) => {
-            if (value && typeof value === 'string') {
-                return fs.createWriteStream(value);
+        })
+        .option('data_file', {
+            description: 'FILE: File to read from file and POST or PUT.',
+            type: 'string'
+        })
+        .option('method', {
+            alias: 'M',
+            description: 'STRING: Http Method verb to use for the request.',
+            choices: ['GET', 'POST', 'PUT', 'DELETE', 'HEAD'],
+            default: 'GET'
+        })
+        .option('get', {
+            alias: 'G',
+            description: 'uses GET for the verb'
+        })
+        .option('post', {
+            alias: 'P',
+            description: 'uses POST for the verb'
+        })
+        .option('head', {
+            alias: 'I',
+            description: 'uses HEAD for the verb'
+        })
+        .option('include', {
+            alias: 'i',
+            description: 'Includes headers in output',
+            type: 'boolean',
+            default: false
+        })
+        .option('insecure', {
+            alias: 'k',
+            description: 'Turns off X.509 validation',
+            type: 'boolean',
+            default: false
+        })
+        .option('output', {
+            alias: 'o',
+            description: 'FILE: dumps content-body to FILE instead of stdout.',
+            type: 'string',
+            default: process.stdout,
+            coerce: (value: string) => {
+                if (value && typeof value === 'string') {
+                    return fs.createWriteStream(value);
+                }
+                return value;
             }
-            return value;
-        }
-    })
-    .option('trace', {
-        alias: 't',
-        description: 'FILE: dumps logs to FILE instead of stderr.',
-        type: 'string',
-        default: undefined
-    })
-    .option('alpn_list', {
-        alias: 'p',
-        description: 'STRING: List of protocols for ALPN, semicolon delimited.'
-    })
-    .option('verbose', {
-        alias: 'v',
-        description: 'ERROR|WARN|INFO|DEBUG|TRACE: log level. Default is none.',
-        choices: ['ERROR', 'WARN', 'INFO', 'DEBUG', 'TRACE', 'NONE'],
-        default: 'NONE'
-    })
-    .help()
-    .alias('help', 'h')
-    .middleware((argv: Args) => {
-        if (argv.get) {
-            argv.method = 'GET';
-        } else if (argv.post) {
-            argv.method = 'POST';
-        } else if (argv.head) {
-            argv.method = 'HEAD';
-        }
+        })
+        .option('trace', {
+            alias: 't',
+            description: 'FILE: dumps logs to FILE instead of stderr.',
+            type: 'string',
+            default: undefined
+        })
+        .option('alpn_list', {
+            alias: 'p',
+            description: 'STRING: List of protocols for ALPN, semicolon delimited.'
+        })
+        .option('verbose', {
+            alias: 'v',
+            description: 'ERROR|WARN|INFO|DEBUG|TRACE: log level. Default is none.',
+            choices: ['ERROR', 'WARN', 'INFO', 'DEBUG', 'TRACE', 'NONE'],
+            default: 'NONE'
+        })
+        .help()
+        .alias('help', 'h')
+        .middleware((argv: Args) => {
+            if (argv.get) {
+                argv.method = 'GET';
+            } else if (argv.post) {
+                argv.method = 'POST';
+            } else if (argv.head) {
+                argv.method = 'HEAD';
+            }
 
-        if (argv.data_file) {
-            argv.data = fs.createReadStream(argv.data_file);
-        }
-    }, true)
-    .showHelpOnFail(false)
+            if (argv.data_file) {
+                argv.data = fs.createReadStream(argv.data_file);
+            }
+        }, true)
+        .showHelpOnFail(false)
 }, main).parse();
 
 function init_logging(argv: Args) {
@@ -178,7 +178,7 @@ function init_tls(argv: Args) {
     return new io.ClientTlsContext(tls_options);
 }
 
-async function main(argv: Args){
+async function main(argv: Args) {
     init_logging(argv);
 
     const client_bootstrap = new io.ClientBootstrap();
@@ -262,7 +262,7 @@ async function main(argv: Args){
             port,
             socket_options,
             tls_opts);
-        
+
         connection.on('connect', async () => {
             if (argv.data) {
                 const data: string = await new Promise((resolve_stream, reject_stream) => {
@@ -294,9 +294,10 @@ async function main(argv: Args){
             resolve_conn();
         });
     });
-    
+
     // make it wait as long as possible once the promise completes we'll turn it off.
-    const timer = setTimeout(() => {}, 2147483647);
+    const timer = setTimeout(() => { }, 2147483647);
     await conn_promise;
+    console.log("done!");
     clearTimeout(timer);
 }

--- a/samples/node/elasticurl/elasticurl.ts
+++ b/samples/node/elasticurl/elasticurl.ts
@@ -5,7 +5,6 @@
 
 import { http, io } from "aws-crt";
 import { PassThrough } from "stream";
-import { TextDecoder } from "util";
 const fs = require('fs');
 
 type Args = { [index: string]: any };
@@ -193,8 +192,6 @@ async function main(argv: Args) {
         port = 443;
     }
 
-    const decoder = new TextDecoder();
-
     const make_request = async (connection: http.HttpClientConnection, body?: string) => {
         const on_response = (status_code: Number, headers: http.HttpHeaders) => {
             console.log("Response Code: " + status_code.toString());
@@ -206,8 +203,8 @@ async function main(argv: Args) {
         };
 
         const on_body = (body: ArrayBuffer) => {
-            const body_str = decoder.decode(body);
-            argv.output.write(body_str);
+            let uint8buffer = new Uint8Array(body);
+            argv.output.write(uint8buffer);
         };
 
         let headers = new http.HttpHeaders([
@@ -298,6 +295,5 @@ async function main(argv: Args) {
     // make it wait as long as possible once the promise completes we'll turn it off.
     const timer = setTimeout(() => { }, 2147483647);
     await conn_promise;
-    console.log("done!");
     clearTimeout(timer);
 }

--- a/samples/node/elasticurl/elasticurl.ts
+++ b/samples/node/elasticurl/elasticurl.ts
@@ -17,125 +17,125 @@ yargs.command('*', false, (yargs: any) => {
         type: 'URL',
         default: new URL(url)
     })
-        .option('cacert', {
-            description: 'FILE: path to a CA certficate file.',
-            type: 'string'
-        })
-        .option('capath', {
-            description: 'PATH: path to a directory containing CA files.',
-            type: 'string'
-        })
-        .option('cert', {
-            description: 'FILE: path to a PEM encoded certificate to use with mTLS',
-            type: 'string'
-        })
-        .option('key', {
-            description: 'FILE: Path to a PEM encoded private key that matches cert.',
-            type: 'string'
-        })
-        .option('connect_timeout', {
-            description: 'INT: time in milliseconds to wait for a connection.',
-            type: 'number',
-            default: 3000,
-        })
-        .option('header', {
-            alias: 'H',
-            description: 'LINE: line to send as a header in format [header-key]: [header-value]\n',
-            type: 'array'
-        })
-        .option('data', {
-            alias: 'd',
-            description: 'STRING: Data to POST or PUT.',
-            type: 'string',
-            default: undefined,
-            coerce: (value: string) => {
-                if (value) {
-                    let stream = new PassThrough();
-                    stream.write(value);
-                    stream.end();
-                    return stream;
-                }
-                return value;
+    .option('cacert', {
+        description: 'FILE: path to a CA certficate file.',
+        type: 'string'
+    })
+    .option('capath', {
+        description: 'PATH: path to a directory containing CA files.',
+        type: 'string'
+    })
+    .option('cert', {
+        description: 'FILE: path to a PEM encoded certificate to use with mTLS',
+        type: 'string'
+    })
+    .option('key', {
+        description: 'FILE: Path to a PEM encoded private key that matches cert.',
+        type: 'string'
+    })
+    .option('connect_timeout', {
+        description: 'INT: time in milliseconds to wait for a connection.',
+        type: 'number',
+        default: 3000,
+    })
+    .option('header', {
+        alias: 'H',
+        description: 'LINE: line to send as a header in format [header-key]: [header-value]\n',
+        type: 'array'
+    })
+    .option('data', {
+        alias: 'd',
+        description: 'STRING: Data to POST or PUT.',
+        type: 'string',
+        default: undefined,
+        coerce: (value: string) => {
+            if (value) {
+                let stream = new PassThrough();
+                stream.write(value);
+                stream.end();
+                return stream;
             }
-        })
-        .option('data_file', {
-            description: 'FILE: File to read from file and POST or PUT.',
-            type: 'string'
-        })
-        .option('method', {
-            alias: 'M',
-            description: 'STRING: Http Method verb to use for the request.',
-            choices: ['GET', 'POST', 'PUT', 'DELETE', 'HEAD'],
-            default: 'GET'
-        })
-        .option('get', {
-            alias: 'G',
-            description: 'uses GET for the verb'
-        })
-        .option('post', {
-            alias: 'P',
-            description: 'uses POST for the verb'
-        })
-        .option('head', {
-            alias: 'I',
-            description: 'uses HEAD for the verb'
-        })
-        .option('include', {
-            alias: 'i',
-            description: 'Includes headers in output',
-            type: 'boolean',
-            default: false
-        })
-        .option('insecure', {
-            alias: 'k',
-            description: 'Turns off X.509 validation',
-            type: 'boolean',
-            default: false
-        })
-        .option('output', {
-            alias: 'o',
-            description: 'FILE: dumps content-body to FILE instead of stdout.',
-            type: 'string',
-            default: process.stdout,
-            coerce: (value: string) => {
-                if (value && typeof value === 'string') {
-                    return fs.createWriteStream(value);
-                }
-                return value;
+            return value;
+        }
+    })
+    .option('data_file', {
+        description: 'FILE: File to read from file and POST or PUT.',
+        type: 'string'
+    })
+    .option('method', {
+        alias: 'M',
+        description: 'STRING: Http Method verb to use for the request.',
+        choices: ['GET', 'POST', 'PUT', 'DELETE', 'HEAD'],
+        default: 'GET'
+    })
+    .option('get', {
+        alias: 'G',
+        description: 'uses GET for the verb'
+    })
+    .option('post', {
+        alias: 'P',
+        description: 'uses POST for the verb'
+    })
+    .option('head', {
+        alias: 'I',
+        description: 'uses HEAD for the verb'
+    })
+    .option('include', {
+        alias: 'i',
+        description: 'Includes headers in output',
+        type: 'boolean',
+        default: false
+    })
+    .option('insecure', {
+        alias: 'k',
+        description: 'Turns off X.509 validation',
+        type: 'boolean',
+        default: false
+    })
+    .option('output', {
+        alias: 'o',
+        description: 'FILE: dumps content-body to FILE instead of stdout.',
+        type: 'string',
+        default: process.stdout,
+        coerce: (value: string) => {
+            if (value && typeof value === 'string') {
+                return fs.createWriteStream(value);
             }
-        })
-        .option('trace', {
-            alias: 't',
-            description: 'FILE: dumps logs to FILE instead of stderr.',
-            type: 'string',
-            default: undefined
-        })
-        .option('alpn_list', {
-            alias: 'p',
-            description: 'STRING: List of protocols for ALPN, semicolon delimited.'
-        })
-        .option('verbose', {
-            alias: 'v',
-            description: 'ERROR|WARN|INFO|DEBUG|TRACE: log level. Default is none.',
-            choices: ['ERROR', 'WARN', 'INFO', 'DEBUG', 'TRACE', 'NONE'],
-            default: 'NONE'
-        })
-        .help()
-        .alias('help', 'h')
-        .middleware((argv: Args) => {
-            if (argv.get) {
-                argv.method = 'GET';
-            } else if (argv.post) {
-                argv.method = 'POST';
-            } else if (argv.head) {
-                argv.method = 'HEAD';
-            }
+            return value;
+        }
+    })
+    .option('trace', {
+        alias: 't',
+        description: 'FILE: dumps logs to FILE instead of stderr.',
+        type: 'string',
+        default: undefined
+    })
+    .option('alpn_list', {
+        alias: 'p',
+        description: 'STRING: List of protocols for ALPN, semicolon delimited.'
+    })
+    .option('verbose', {
+        alias: 'v',
+        description: 'ERROR|WARN|INFO|DEBUG|TRACE: log level. Default is none.',
+        choices: ['ERROR', 'WARN', 'INFO', 'DEBUG', 'TRACE', 'NONE'],
+        default: 'NONE'
+    })
+    .help()
+    .alias('help', 'h')
+    .middleware((argv: Args) => {
+        if (argv.get) {
+            argv.method = 'GET';
+        } else if (argv.post) {
+            argv.method = 'POST';
+        } else if (argv.head) {
+            argv.method = 'HEAD';
+        }
 
-            if (argv.data_file) {
-                argv.data = fs.createReadStream(argv.data_file);
-            }
-        }, true)
-        .showHelpOnFail(false)
+        if (argv.data_file) {
+            argv.data = fs.createReadStream(argv.data_file);
+        }
+    }, true)
+    .showHelpOnFail(false)
 }, main).parse();
 
 function init_logging(argv: Args) {
@@ -177,7 +177,7 @@ function init_tls(argv: Args) {
     return new io.ClientTlsContext(tls_options);
 }
 
-async function main(argv: Args) {
+async function main(argv: Args){
     init_logging(argv);
 
     const client_bootstrap = new io.ClientBootstrap();
@@ -259,7 +259,7 @@ async function main(argv: Args) {
             port,
             socket_options,
             tls_opts);
-
+        
         connection.on('connect', async () => {
             if (argv.data) {
                 const data: string = await new Promise((resolve_stream, reject_stream) => {
@@ -291,9 +291,9 @@ async function main(argv: Args) {
             resolve_conn();
         });
     });
-
+    
     // make it wait as long as possible once the promise completes we'll turn it off.
-    const timer = setTimeout(() => { }, 2147483647);
+    const timer = setTimeout(() => {}, 2147483647);
     await conn_promise;
     clearTimeout(timer);
 }

--- a/samples/node/elasticurl/package-lock.json
+++ b/samples/node/elasticurl/package-lock.json
@@ -26,11 +26,11 @@
     "aws-crt": {
       "version": "file:../../..",
       "requires": {
-        "axios": "^0.19.2",
+        "axios": "^0.21.1",
         "cmake-js": "^6.1.0",
         "crypto-js": "^3.3.0",
-        "fastestsmallesttextencoderdecoder": "^1.0.21",
-        "mqtt": "^4.1.0",
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "mqtt": "^4.2.6",
         "websocket-stream": "^5.5.2"
       },
       "dependencies": {
@@ -77,7 +77,7 @@
         "asn1": {
           "version": "0.2.4",
           "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-          "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+          "integrity": "sha1-jSR136tVO7M+d7VOWeiAu4ziMTY=",
           "requires": {
             "safer-buffer": "~2.1.0"
           }
@@ -611,7 +611,7 @@
         "form-data": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-          "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+          "integrity": "sha1-3M5SwF9kTymManq5Nr1yTO/786Y=",
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.6",
@@ -898,7 +898,7 @@
         "json-schema-traverse": {
           "version": "0.4.1",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+          "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA="
         },
         "json-stable-stringify-without-jsonify": {
           "version": "1.0.1",
@@ -1193,7 +1193,7 @@
         "oauth-sign": {
           "version": "0.9.0",
           "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-          "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+          "integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU="
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1306,7 +1306,7 @@
         "qs": {
           "version": "6.5.2",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+          "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY="
         },
         "rc": {
           "version": "1.2.8",
@@ -1441,7 +1441,7 @@
         "sshpk": {
           "version": "1.16.1",
           "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-          "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+          "integrity": "sha1-+2YcC+8ps520B2nuOfpwCT1vaHc=",
           "requires": {
             "asn1": "~0.2.3",
             "assert-plus": "^1.0.0",
@@ -1637,7 +1637,7 @@
         "uri-js": {
           "version": "4.2.2",
           "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-          "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+          "integrity": "sha1-lMVA4f93KVbiKZUHwBCupsiDjrA=",
           "requires": {
             "punycode": "^2.1.0"
           }
@@ -1683,7 +1683,7 @@
         "which": {
           "version": "1.3.1",
           "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
           "requires": {
             "isexe": "^2.0.0"
           }

--- a/samples/node/elasticurl/package-lock.json
+++ b/samples/node/elasticurl/package-lock.json
@@ -118,11 +118,11 @@
           "integrity": "sha512-gNJMwfBQe8LkPU5JSN11YEUYL1rHSnqOVzM0vY80PQguNzln0T5IdJKDKnBfrKyUNNujOfs7SHLmkdsdBRZ5fg=="
         },
         "axios": {
-          "version": "0.19.2",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-          "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+          "version": "0.21.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+          "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
           "requires": {
-            "follow-redirects": "1.5.10"
+            "follow-redirects": "^1.10.0"
           }
         },
         "balanced-match": {
@@ -131,9 +131,9 @@
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "base64-js": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-          "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+          "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
         },
         "bcrypt-pbkdf": {
           "version": "1.0.2",
@@ -158,9 +158,9 @@
           }
         },
         "bl": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
-          "integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+          "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
           "requires": {
             "buffer": "^5.5.0",
             "inherits": "^2.0.4",
@@ -194,12 +194,12 @@
           }
         },
         "buffer": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
           "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4"
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
           }
         },
         "buffer-from": {
@@ -355,14 +355,26 @@
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "concat-stream": {
-          "version": "1.6.2",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-          "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+          "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
           "requires": {
             "buffer-from": "^1.0.0",
             "inherits": "^2.0.3",
-            "readable-stream": "^2.2.2",
+            "readable-stream": "^3.0.2",
             "typedarray": "^0.0.6"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "3.6.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+              "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+              "requires": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+              }
+            }
           }
         },
         "console-control-strings": {
@@ -379,15 +391,6 @@
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.3.0.tgz",
           "integrity": "sha512-DIT51nX0dCfKltpRiXV+/TVZq+Qq2NgF4644+K7Ttnla7zEzqc+kjJyiB96BHNyUTBxyjzRcZYpUdZa+QAqi6Q=="
-        },
-        "d": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
-          "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-          "requires": {
-            "es5-ext": "^0.10.50",
-            "type": "^1.0.1"
-          }
         },
         "dashdash": {
           "version": "1.14.1",
@@ -466,95 +469,6 @@
             "once": "^1.4.0"
           }
         },
-        "es5-ext": {
-          "version": "0.10.53",
-          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-          "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
-          "requires": {
-            "es6-iterator": "~2.0.3",
-            "es6-symbol": "~3.1.3",
-            "next-tick": "~1.0.0"
-          }
-        },
-        "es6-iterator": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-          "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-          "requires": {
-            "d": "1",
-            "es5-ext": "^0.10.35",
-            "es6-symbol": "^3.1.1"
-          }
-        },
-        "es6-map": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
-          "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
-          "requires": {
-            "d": "1",
-            "es5-ext": "~0.10.14",
-            "es6-iterator": "~2.0.1",
-            "es6-set": "~0.1.5",
-            "es6-symbol": "~3.1.1",
-            "event-emitter": "~0.3.5"
-          }
-        },
-        "es6-set": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
-          "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
-          "requires": {
-            "d": "1",
-            "es5-ext": "~0.10.14",
-            "es6-iterator": "~2.0.1",
-            "es6-symbol": "3.1.1",
-            "event-emitter": "~0.3.5"
-          },
-          "dependencies": {
-            "es6-symbol": {
-              "version": "3.1.1",
-              "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-              "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-              "requires": {
-                "d": "1",
-                "es5-ext": "~0.10.14"
-              }
-            }
-          }
-        },
-        "es6-symbol": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
-          "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
-          "requires": {
-            "d": "^1.0.1",
-            "ext": "^1.1.2"
-          }
-        },
-        "event-emitter": {
-          "version": "0.3.5",
-          "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-          "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-          "requires": {
-            "d": "1",
-            "es5-ext": "~0.10.14"
-          }
-        },
-        "ext": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
-          "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
-          "requires": {
-            "type": "^2.0.0"
-          },
-          "dependencies": {
-            "type": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/type/-/type-2.1.0.tgz",
-              "integrity": "sha512-G9absDWvhAWCV2gmF1zKud3OyC61nZDwWvBL2DApaVFogI07CprggiQAOOjvp2NRjYWFzPyu7vwtDrQFq8jeSA=="
-            }
-          }
-        },
         "extend": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -581,27 +495,9 @@
           "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw=="
         },
         "follow-redirects": {
-          "version": "1.5.10",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-          "requires": {
-            "debug": "=3.1.0"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "ms": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-            }
-          }
+          "version": "1.13.3",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.3.tgz",
+          "integrity": "sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA=="
         },
         "forever-agent": {
           "version": "0.6.1",
@@ -768,9 +664,9 @@
           }
         },
         "ieee754": {
-          "version": "1.1.13",
-          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-          "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+          "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
         },
         "ignore-walk": {
           "version": "3.0.2",
@@ -1050,67 +946,67 @@
           }
         },
         "mqtt": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-4.2.1.tgz",
-          "integrity": "sha512-Iv893r+jWlo5GkNcPOfCGwW8M49IixwHiKLFFYTociEymSibUVCORVEjPXWPGzSxhn7BdlUeHicbRmWiv0Crkg==",
+          "version": "4.2.6",
+          "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-4.2.6.tgz",
+          "integrity": "sha512-GpxVObyOzL0CGPBqo6B04GinN8JLk12NRYAIkYvARd9ZCoJKevvOyCaWK6bdK/kFSDj3LPDnCsJbezzNlsi87Q==",
           "requires": {
-            "base64-js": "^1.3.0",
             "commist": "^1.0.0",
-            "concat-stream": "^1.6.2",
+            "concat-stream": "^2.0.0",
             "debug": "^4.1.1",
-            "end-of-stream": "^1.4.1",
-            "es6-map": "^0.1.5",
             "help-me": "^1.0.1",
             "inherits": "^2.0.3",
             "minimist": "^1.2.5",
-            "mqtt-packet": "^6.3.2",
+            "mqtt-packet": "^6.6.0",
             "pump": "^3.0.0",
-            "readable-stream": "^2.3.6",
+            "readable-stream": "^3.6.0",
             "reinterval": "^1.1.0",
             "split2": "^3.1.0",
             "ws": "^7.3.1",
-            "xtend": "^4.0.1"
+            "xtend": "^4.0.2"
           },
           "dependencies": {
             "debug": {
-              "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-              "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+              "version": "4.3.1",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+              "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
               "requires": {
-                "ms": "^2.1.1"
+                "ms": "2.1.2"
+              }
+            },
+            "readable-stream": {
+              "version": "3.6.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+              "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+              "requires": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
               }
             },
             "ws": {
-              "version": "7.3.1",
-              "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
-              "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA=="
+              "version": "7.4.3",
+              "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.3.tgz",
+              "integrity": "sha512-hr6vCR76GsossIRsr8OLR9acVVm1jyfEWvhbNjtgPOrfvAlKzvyeg/P6r8RuDjRyrcQoPQT7K0DGEPc7Ae6jzA=="
             }
           }
         },
         "mqtt-packet": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-6.4.0.tgz",
-          "integrity": "sha512-dNd1RPyBolklOR27hgHhy3TxkDk31ZaDu4ljAgJoHlnVsdACH8guwEZhpk3ZMn6GAdH6ENDLgtE285FHIiXzxA==",
+          "version": "6.9.0",
+          "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-6.9.0.tgz",
+          "integrity": "sha512-cngFSAXWSl5XHKJYUQiYQjtp75zhf1vygY00NnJdhQoXOH2v3aizmaaMIHI5n1N/TJEHSAbHryQhFr3gJ9VNvA==",
           "requires": {
             "bl": "^4.0.2",
             "debug": "^4.1.1",
-            "inherits": "^2.0.4",
-            "process-nextick-args": "^2.0.1",
-            "safe-buffer": "^5.2.1"
+            "process-nextick-args": "^2.0.1"
           },
           "dependencies": {
             "debug": {
-              "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-              "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+              "version": "4.3.1",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+              "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
               "requires": {
-                "ms": "^2.1.1"
+                "ms": "2.1.2"
               }
-            },
-            "safe-buffer": {
-              "version": "5.2.1",
-              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-              "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
             }
           }
         },
@@ -1128,11 +1024,6 @@
             "iconv-lite": "^0.4.4",
             "sax": "^1.2.4"
           }
-        },
-        "next-tick": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-          "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
         },
         "node-pre-gyp": {
           "version": "0.12.0",
@@ -1557,11 +1448,6 @@
           "version": "0.14.5",
           "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
           "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
-        },
-        "type": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-          "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
         },
         "typedarray": {
           "version": "0.0.6",

--- a/source/auth.c
+++ b/source/auth.c
@@ -230,7 +230,7 @@ static void s_destroy_signing_binding(
 
     aws_signable_destroy(binding->signable);
 
-    AWS_NAPI_ENSURE(env, napi_unref_threadsafe_function(env, binding->on_complete));
+    AWS_NAPI_ENSURE(env, aws_napi_unref_threadsafe_function(env, binding->on_complete));
     aws_mem_release(allocator, binding);
 }
 

--- a/source/auth.c
+++ b/source/auth.c
@@ -540,8 +540,8 @@ static napi_value s_aws_sign_request(napi_env env, const struct aws_napi_callbac
             (struct aws_signing_config_base *)&config,
             s_aws_sign_request_complete,
             state)) {
-        AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(state->on_complete, napi_tsfn_abort));
         aws_napi_throw_last_error(env);
+        // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(state->on_complete, napi_tsfn_abort));
     }
 
     goto done;

--- a/source/auth.c
+++ b/source/auth.c
@@ -540,7 +540,7 @@ static napi_value s_aws_sign_request(napi_env env, const struct aws_napi_callbac
             (struct aws_signing_config_base *)&config,
             s_aws_sign_request_complete,
             state)) {
-        AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->on_complete, napi_tsfn_abort));
+        AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(state->on_complete, napi_tsfn_abort));
         aws_napi_throw_last_error(env);
     }
 

--- a/source/auth.c
+++ b/source/auth.c
@@ -230,7 +230,7 @@ static void s_destroy_signing_binding(
 
     aws_signable_destroy(binding->signable);
 
-    AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->on_complete, napi_tsfn_abort));
+    AWS_NAPI_ENSURE(env, napi_unref_threadsafe_function(env, binding->on_complete));
     aws_mem_release(allocator, binding);
 }
 
@@ -541,7 +541,7 @@ static napi_value s_aws_sign_request(napi_env env, const struct aws_napi_callbac
             s_aws_sign_request_complete,
             state)) {
         aws_napi_throw_last_error(env);
-        // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(state->on_complete, napi_tsfn_abort));
+        AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(state->on_complete, napi_tsfn_abort));
     }
 
     goto done;

--- a/source/auth.c
+++ b/source/auth.c
@@ -230,6 +230,7 @@ static void s_destroy_signing_binding(
 
     aws_signable_destroy(binding->signable);
 
+    AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->on_complete, napi_tsfn_abort));
     aws_mem_release(allocator, binding);
 }
 

--- a/source/auth.c
+++ b/source/auth.c
@@ -540,7 +540,7 @@ static napi_value s_aws_sign_request(napi_env env, const struct aws_napi_callbac
             (struct aws_signing_config_base *)&config,
             s_aws_sign_request_complete,
             state)) {
-
+        AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->on_complete, napi_tsfn_abort));
         aws_napi_throw_last_error(env);
     }
 

--- a/source/http_connection.c
+++ b/source/http_connection.c
@@ -130,10 +130,11 @@ struct http_connection_binding {
 
 /* finalizer called when node cleans up this object */
 static void s_http_connection_from_manager_binding_finalize(napi_env env, void *finalize_data, void *finalize_hint) {
-    (void)env;
     (void)finalize_hint;
     struct http_connection_binding *binding = finalize_data;
 
+    AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->on_setup, napi_tsfn_abort));
+    AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->on_shutdown, napi_tsfn_abort));
     /* no release call, the http_client_connection_manager has already released it */
     aws_mem_release(binding->allocator, binding);
 }

--- a/source/http_connection.c
+++ b/source/http_connection.c
@@ -131,10 +131,11 @@ struct http_connection_binding {
 /* finalizer called when node cleans up this object */
 static void s_http_connection_from_manager_binding_finalize(napi_env env, void *finalize_data, void *finalize_hint) {
     (void)finalize_hint;
+    (void)env;
     struct http_connection_binding *binding = finalize_data;
 
-    AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->on_setup, napi_tsfn_abort));
-    AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->on_shutdown, napi_tsfn_abort));
+    // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(binding->on_setup, napi_tsfn_abort));
+    // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(binding->on_shutdown, napi_tsfn_abort));
     /* no release call, the http_client_connection_manager has already released it */
     aws_mem_release(binding->allocator, binding);
 }
@@ -390,8 +391,8 @@ connect_failed:
 create_external_failed:
 failed_callbacks:
     if (binding) {
-        AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->on_setup, napi_tsfn_abort));
-        AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->on_shutdown, napi_tsfn_abort));
+        // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(binding->on_setup, napi_tsfn_abort));
+        // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(binding->on_shutdown, napi_tsfn_abort));
     }
     aws_mem_release(allocator, binding);
 alloc_failed:

--- a/source/http_connection.c
+++ b/source/http_connection.c
@@ -134,8 +134,8 @@ static void s_http_connection_from_manager_binding_finalize(napi_env env, void *
     (void)env;
     struct http_connection_binding *binding = finalize_data;
 
-    // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(binding->on_setup, napi_tsfn_abort));
-    // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(binding->on_shutdown, napi_tsfn_abort));
+    AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->on_setup, napi_tsfn_abort));
+    AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->on_shutdown, napi_tsfn_abort));
     /* no release call, the http_client_connection_manager has already released it */
     aws_mem_release(binding->allocator, binding);
 }
@@ -391,8 +391,8 @@ connect_failed:
 create_external_failed:
 failed_callbacks:
     if (binding) {
-        // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(binding->on_setup, napi_tsfn_abort));
-        // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(binding->on_shutdown, napi_tsfn_abort));
+        AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->on_setup, napi_tsfn_abort));
+        AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->on_shutdown, napi_tsfn_abort));
     }
     aws_mem_release(allocator, binding);
 alloc_failed:

--- a/source/http_connection.c
+++ b/source/http_connection.c
@@ -134,8 +134,6 @@ static void s_http_connection_from_manager_binding_finalize(napi_env env, void *
     (void)env;
     struct http_connection_binding *binding = finalize_data;
 
-    AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->on_setup, napi_tsfn_abort));
-    AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->on_shutdown, napi_tsfn_abort));
     /* no release call, the http_client_connection_manager has already released it */
     aws_mem_release(binding->allocator, binding);
 }
@@ -176,15 +174,18 @@ static void s_http_on_connection_setup_call(napi_env env, napi_value on_setup, v
     struct http_connection_binding *binding = context;
     struct on_connection_args *args = user_data;
 
-    if (env) {
-        napi_value params[2];
-        const size_t num_params = AWS_ARRAY_SIZE(params);
+    napi_value params[2];
+    const size_t num_params = AWS_ARRAY_SIZE(params);
 
-        AWS_NAPI_ENSURE(env, napi_get_reference_value(env, args->binding->node_external, &params[0]));
-        AWS_NAPI_ENSURE(env, napi_create_uint32(env, args->error_code, &params[1]));
+    AWS_NAPI_ENSURE(env, napi_get_reference_value(env, args->binding->node_external, &params[0]));
+    AWS_NAPI_ENSURE(env, napi_create_uint32(env, args->error_code, &params[1]));
 
-        AWS_NAPI_ENSURE(
-            env, aws_napi_dispatch_threadsafe_function(env, binding->on_setup, NULL, on_setup, num_params, params));
+    AWS_NAPI_ENSURE(
+        env, aws_napi_dispatch_threadsafe_function(env, binding->on_setup, NULL, on_setup, num_params, params));
+    AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->on_setup, napi_tsfn_abort));
+    if (args->error_code) {
+        /* setup failed, shutdown will never get invoked. Clean up the functions here */
+        AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->on_shutdown, napi_tsfn_abort));
     }
 
     aws_mem_release(binding->allocator, args);
@@ -217,6 +218,7 @@ static void s_http_on_connection_shutdown_call(napi_env env, napi_value on_shutd
             aws_napi_dispatch_threadsafe_function(env, binding->on_shutdown, NULL, on_shutdown, num_params, params));
     }
 
+    AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->on_shutdown, napi_tsfn_abort));
     aws_mem_release(binding->allocator, args);
 }
 

--- a/source/http_connection.c
+++ b/source/http_connection.c
@@ -390,12 +390,8 @@ connect_failed:
 create_external_failed:
 failed_callbacks:
     if (binding) {
-        if (binding->on_setup) {
-            AWS_NAPI_ENSURE(env, napi_release_threadsafe_function(binding->on_setup, napi_tsfn_abort));
-        }
-        if (binding->on_shutdown) {
-            AWS_NAPI_ENSURE(env, napi_release_threadsafe_function(binding->on_shutdown, napi_tsfn_abort));
-        }
+        AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->on_setup, napi_tsfn_abort));
+        AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->on_shutdown, napi_tsfn_abort));
     }
     aws_mem_release(allocator, binding);
 alloc_failed:

--- a/source/http_connection_manager.c
+++ b/source/http_connection_manager.c
@@ -28,7 +28,7 @@ static void s_http_connection_manager_finalize(napi_env env, void *finalize_data
     (void)finalize_hint;
     (void)env;
     struct http_connection_manager_binding *binding = finalize_data;
-    // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(binding->on_shutdown, napi_tsfn_abort));
+    AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->on_shutdown, napi_tsfn_abort));
     aws_mem_release(binding->allocator, binding);
 }
 
@@ -257,7 +257,7 @@ static void s_http_connection_manager_on_acquired_call(
     AWS_NAPI_ENSURE(
         env, aws_napi_dispatch_threadsafe_function(env, args->on_acquired, NULL, on_acquired, num_params, params));
 
-    // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(args->on_acquired, napi_tsfn_abort));
+    // AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(args->on_acquired, napi_tsfn_abort));
     aws_mem_release(binding->allocator, args);
 }
 

--- a/source/http_connection_manager.c
+++ b/source/http_connection_manager.c
@@ -257,7 +257,7 @@ static void s_http_connection_manager_on_acquired_call(
     AWS_NAPI_ENSURE(
         env, aws_napi_dispatch_threadsafe_function(env, args->on_acquired, NULL, on_acquired, num_params, params));
 
-    // AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(args->on_acquired, napi_tsfn_abort));
+    AWS_NAPI_ENSURE(env, aws_napi_unref_threadsafe_function(env, args->on_acquired));
     aws_mem_release(binding->allocator, args);
 }
 

--- a/source/http_connection_manager.c
+++ b/source/http_connection_manager.c
@@ -26,8 +26,9 @@ struct aws_http_connection_manager *aws_napi_get_http_connection_manager(
 
 static void s_http_connection_manager_finalize(napi_env env, void *finalize_data, void *finalize_hint) {
     (void)finalize_hint;
+    (void)env;
     struct http_connection_manager_binding *binding = finalize_data;
-    AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->on_shutdown, napi_tsfn_abort));
+    // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(binding->on_shutdown, napi_tsfn_abort));
     aws_mem_release(binding->allocator, binding);
 }
 
@@ -256,7 +257,7 @@ static void s_http_connection_manager_on_acquired_call(
     AWS_NAPI_ENSURE(
         env, aws_napi_dispatch_threadsafe_function(env, args->on_acquired, NULL, on_acquired, num_params, params));
 
-    AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(args->on_acquired, napi_tsfn_abort));
+    // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(args->on_acquired, napi_tsfn_abort));
     aws_mem_release(binding->allocator, args);
 }
 

--- a/source/http_connection_manager.c
+++ b/source/http_connection_manager.c
@@ -25,9 +25,9 @@ struct aws_http_connection_manager *aws_napi_get_http_connection_manager(
 }
 
 static void s_http_connection_manager_finalize(napi_env env, void *finalize_data, void *finalize_hint) {
-    (void)env;
     (void)finalize_hint;
     struct http_connection_manager_binding *binding = finalize_data;
+    AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->on_shutdown, napi_tsfn_abort));
     aws_mem_release(binding->allocator, binding);
 }
 
@@ -245,19 +245,18 @@ static void s_http_connection_manager_on_acquired_call(
     struct http_connection_manager_binding *binding = context;
     struct connection_acquired_args *args = user_data;
 
-    if (env) {
-        napi_value connection_external = aws_napi_http_connection_from_manager(env, args->connection);
-        AWS_FATAL_ASSERT(connection_external);
+    napi_value connection_external = aws_napi_http_connection_from_manager(env, args->connection);
+    AWS_FATAL_ASSERT(connection_external);
 
-        napi_value params[2];
-        const size_t num_params = AWS_ARRAY_SIZE(params);
-        params[0] = connection_external;
-        AWS_NAPI_ENSURE(env, napi_create_int32(env, args->error_code, &params[1]));
+    napi_value params[2];
+    const size_t num_params = AWS_ARRAY_SIZE(params);
+    params[0] = connection_external;
+    AWS_NAPI_ENSURE(env, napi_create_int32(env, args->error_code, &params[1]));
 
-        AWS_NAPI_ENSURE(
-            env, aws_napi_dispatch_threadsafe_function(env, args->on_acquired, NULL, on_acquired, num_params, params));
-    }
+    AWS_NAPI_ENSURE(
+        env, aws_napi_dispatch_threadsafe_function(env, args->on_acquired, NULL, on_acquired, num_params, params));
 
+    AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(args->on_acquired, napi_tsfn_abort));
     aws_mem_release(binding->allocator, args);
 }
 

--- a/source/http_connection_manager.c
+++ b/source/http_connection_manager.c
@@ -28,7 +28,6 @@ static void s_http_connection_manager_finalize(napi_env env, void *finalize_data
     (void)finalize_hint;
     (void)env;
     struct http_connection_manager_binding *binding = finalize_data;
-    AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->on_shutdown, napi_tsfn_abort));
     aws_mem_release(binding->allocator, binding);
 }
 
@@ -50,6 +49,7 @@ static void s_http_connection_manager_shutdown_complete(void *user_data) {
     if (binding->on_shutdown) {
         AWS_NAPI_ENSURE(NULL, aws_napi_queue_threadsafe_function(binding->on_shutdown, NULL));
     }
+    AWS_NAPI_ENSURE(binding->env, aws_napi_release_threadsafe_function(binding->on_shutdown, napi_tsfn_abort));
 }
 
 napi_value aws_napi_http_connection_manager_new(napi_env env, napi_callback_info info) {

--- a/source/http_stream.c
+++ b/source/http_stream.c
@@ -308,15 +308,9 @@ failed_request:
 failed_external:
 failed_callbacks:
     if (binding) {
-        if (binding->on_complete) {
-            AWS_NAPI_ENSURE(env, napi_release_threadsafe_function(binding->on_complete, napi_tsfn_abort));
-        }
-        if (binding->on_response) {
-            AWS_NAPI_ENSURE(env, napi_release_threadsafe_function(binding->on_response, napi_tsfn_abort));
-        }
-        if (binding->on_body) {
-            AWS_NAPI_ENSURE(env, napi_release_threadsafe_function(binding->on_body, napi_tsfn_abort));
-        }
+        AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->on_complete, napi_tsfn_abort));
+        AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->on_response, napi_tsfn_abort));
+        AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->on_body, napi_tsfn_abort));
     }
     aws_mem_release(allocator, binding);
 failed_binding_alloc:

--- a/source/http_stream.c
+++ b/source/http_stream.c
@@ -192,6 +192,9 @@ static void s_http_stream_binding_finalize(napi_env env, void *finalize_data, vo
     (void)finalize_hint;
     struct http_stream_binding *binding = finalize_data;
 
+    AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->on_response, napi_tsfn_abort));
+    AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->on_body, napi_tsfn_abort));
+    AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->on_complete, napi_tsfn_abort));
     aws_http_message_release(binding->request);
     aws_http_message_release(binding->response);
     aws_mem_release(binding->allocator, binding);

--- a/source/http_stream.c
+++ b/source/http_stream.c
@@ -116,6 +116,7 @@ static int s_on_response_header_block_done(
 struct on_body_args {
     struct http_stream_binding *binding;
     struct aws_byte_buf chunk;
+    struct aws_allocator *allocator;
 };
 
 static void s_external_arraybuffer_finalizer(napi_env env, void *finalize_data, void *finalize_hint) {
@@ -123,7 +124,7 @@ static void s_external_arraybuffer_finalizer(napi_env env, void *finalize_data, 
     (void)finalize_data;
     struct on_body_args *args = finalize_hint;
     aws_byte_buf_clean_up(&args->chunk);
-    aws_mem_release(args->binding->allocator, args);
+    aws_mem_release(args->allocator, args);
 }
 
 static void s_on_body_call(napi_env env, napi_value on_body, void *context, void *user_data) {
@@ -153,6 +154,7 @@ static int s_on_response_body(struct aws_http_stream *stream, const struct aws_b
 
     struct on_body_args *args = aws_mem_calloc(binding->allocator, 1, sizeof(struct on_body_args));
     AWS_FATAL_ASSERT(args);
+    args->allocator = binding->allocator;
 
     /* recording the length of data that has been pending to be invoked for nodejs */
     aws_atomic_fetch_add(&binding->pending_length, data->len);

--- a/source/http_stream.c
+++ b/source/http_stream.c
@@ -192,9 +192,9 @@ static void s_http_stream_binding_finalize(napi_env env, void *finalize_data, vo
     (void)finalize_hint;
     struct http_stream_binding *binding = finalize_data;
 
-    // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(binding->on_response, napi_tsfn_abort));
-    // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(binding->on_body, napi_tsfn_abort));
-    // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(binding->on_complete, napi_tsfn_abort));
+    AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->on_response, napi_tsfn_abort));
+    AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->on_body, napi_tsfn_abort));
+    AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->on_complete, napi_tsfn_abort));
     aws_http_message_release(binding->request);
     aws_http_message_release(binding->response);
     aws_mem_release(binding->allocator, binding);
@@ -308,9 +308,9 @@ failed_request:
 failed_external:
 failed_callbacks:
     if (binding) {
-        // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(binding->on_complete, napi_tsfn_abort));
-        // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(binding->on_response, napi_tsfn_abort));
-        // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(binding->on_body, napi_tsfn_abort));
+        AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->on_complete, napi_tsfn_abort));
+        AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->on_response, napi_tsfn_abort));
+        AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->on_body, napi_tsfn_abort));
     }
     aws_mem_release(allocator, binding);
 failed_binding_alloc:

--- a/source/http_stream.c
+++ b/source/http_stream.c
@@ -192,9 +192,9 @@ static void s_http_stream_binding_finalize(napi_env env, void *finalize_data, vo
     (void)finalize_hint;
     struct http_stream_binding *binding = finalize_data;
 
-    AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->on_response, napi_tsfn_abort));
-    AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->on_body, napi_tsfn_abort));
-    AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->on_complete, napi_tsfn_abort));
+    // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(binding->on_response, napi_tsfn_abort));
+    // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(binding->on_body, napi_tsfn_abort));
+    // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(binding->on_complete, napi_tsfn_abort));
     aws_http_message_release(binding->request);
     aws_http_message_release(binding->response);
     aws_mem_release(binding->allocator, binding);
@@ -308,9 +308,9 @@ failed_request:
 failed_external:
 failed_callbacks:
     if (binding) {
-        AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->on_complete, napi_tsfn_abort));
-        AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->on_response, napi_tsfn_abort));
-        AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->on_body, napi_tsfn_abort));
+        // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(binding->on_complete, napi_tsfn_abort));
+        // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(binding->on_response, napi_tsfn_abort));
+        // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(binding->on_body, napi_tsfn_abort));
     }
     aws_mem_release(allocator, binding);
 failed_binding_alloc:

--- a/source/http_stream.c
+++ b/source/http_stream.c
@@ -7,6 +7,7 @@
 #include "http_connection.h"
 #include "http_message.h"
 
+#include <aws/common/atomics.h>
 #include <aws/http/request_response.h>
 #include <aws/io/stream.h>
 
@@ -24,8 +25,7 @@ struct http_stream_binding {
     struct aws_http_message *response; /* used to buffer response headers/status code */
     struct aws_http_message *request;
 
-    uint64_t pending_length; /* used to check all the body callbacks for nodejs has been invoked */
-    uint32_t count;
+    struct aws_atomic_var pending_length; /* used to ensure that all of the body callbacks to node have been invoked */
 };
 
 static void s_on_response_call(napi_env env, napi_value on_response, void *context, void *user_data) {
@@ -116,8 +116,6 @@ static int s_on_response_header_block_done(
 struct on_body_args {
     struct http_stream_binding *binding;
     struct aws_byte_buf chunk;
-
-    int index;
 };
 
 static void s_external_arraybuffer_finalizer(napi_env env, void *finalize_data, void *finalize_hint) {
@@ -132,8 +130,8 @@ static void s_on_body_call(napi_env env, napi_value on_body, void *context, void
     struct http_stream_binding *binding = context;
     struct on_body_args *args = user_data;
 
-    /* The callback has been invoked for the nodejs, update the pending length */
-    binding->pending_length -= args->chunk.len;
+    /* Callback is invoked for nodejs, update pending length */
+    aws_atomic_fetch_sub(&binding->pending_length, args->chunk.len);
     napi_value params[1];
     const size_t num_params = AWS_ARRAY_SIZE(params);
 
@@ -157,9 +155,7 @@ static int s_on_response_body(struct aws_http_stream *stream, const struct aws_b
     AWS_FATAL_ASSERT(args);
 
     /* recording the length of data that has been pending to be invoked for nodejs */
-    binding->pending_length += data->len;
-    binding->count++;
-    args->index = binding->count;
+    aws_atomic_fetch_add(&binding->pending_length, data->len);
     args->binding = binding;
     if (aws_byte_buf_init_copy_from_cursor(&args->chunk, binding->allocator, *data)) {
         AWS_FATAL_ASSERT(args->chunk.buffer);
@@ -178,8 +174,7 @@ struct on_complete_args {
 static void s_on_complete_call(napi_env env, napi_value on_complete, void *context, void *user_data) {
     struct http_stream_binding *binding = context;
     struct on_complete_args *args = user_data;
-
-    if (binding->pending_length) {
+    if (aws_atomic_load_int(&binding->pending_length)) {
         /* which means nodejs still has some body callbacks that are pending, cannot complete the stream for nodejs.
          * Requeue the threadsafe function */
         AWS_NAPI_ENSURE(env, aws_napi_queue_threadsafe_function(binding->on_complete, args));
@@ -195,7 +190,7 @@ static void s_on_complete_call(napi_env env, napi_value on_complete, void *conte
     AWS_NAPI_ENSURE(
         env, aws_napi_dispatch_threadsafe_function(env, binding->on_complete, NULL, on_complete, num_params, params));
 
-    /* No callbacks should happen now, cleanup all the threadsafe function */
+    /* No callbacks should happen now, cleanup all the threadsafe functions */
     AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->on_response, napi_tsfn_abort));
     AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->on_body, napi_tsfn_abort));
     AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->on_complete, napi_tsfn_abort));
@@ -263,6 +258,7 @@ napi_value aws_napi_http_stream_new(napi_env env, napi_callback_info info) {
 
     binding->allocator = allocator;
     binding->request = request;
+    aws_atomic_init_int(&binding->pending_length, 0);
 
     AWS_NAPI_CALL(
         env,

--- a/source/module.c
+++ b/source/module.c
@@ -490,7 +490,7 @@ static void s_napi_context_finalize(napi_env env, void *user_data, void *finaliz
     (void)env;
     (void)finalize_hint;
 
-    aws_thread_join_all_managed();
+    // aws_thread_join_all_managed();
 
     struct aws_napi_context *ctx = user_data;
     aws_napi_logger_destroy(ctx->logger);

--- a/source/module.c
+++ b/source/module.c
@@ -368,6 +368,8 @@ napi_status aws_napi_dispatch_threadsafe_function(
     });
     /* Must always decrement the ref count, or the function will be pinned */
     napi_status release_status = napi_release_threadsafe_function(tsfn, napi_tsfn_release);
+    /* main thread can exit now */
+    AWS_NAPI_ENSURE(env, napi_unref_threadsafe_function(env, tsfn));
     return (call_status != napi_ok) ? call_status : release_status;
 }
 
@@ -386,8 +388,7 @@ napi_status aws_napi_create_threadsafe_function(
         env,
         napi_create_threadsafe_function(env, function, NULL, resource_name, 0, 1, NULL, NULL, context, call_js, result),
         { return status; });
-    /* convert to a weak reference */
-    return napi_unref_threadsafe_function(env, *result);
+    return napi_ok;
 }
 
 napi_status aws_napi_queue_threadsafe_function(napi_threadsafe_function function, void *user_data) {

--- a/source/module.c
+++ b/source/module.c
@@ -395,6 +395,13 @@ napi_status aws_napi_release_threadsafe_function(
     return napi_ok;
 }
 
+napi_status aws_napi_unref_threadsafe_function(napi_env env, napi_threadsafe_function function) {
+    if (function) {
+        return napi_unref_threadsafe_function(env, function);
+    }
+    return napi_ok;
+}
+
 napi_status aws_napi_queue_threadsafe_function(napi_threadsafe_function function, void *user_data) {
     /* increase the ref count, gets decreased when the call completes */
     AWS_NAPI_ENSURE(NULL, napi_acquire_threadsafe_function(function));

--- a/source/module.c
+++ b/source/module.c
@@ -489,8 +489,9 @@ static void s_install_crash_handler(void) {
 static void s_napi_context_finalize(napi_env env, void *user_data, void *finalize_hint) {
     (void)env;
     (void)finalize_hint;
+    aws_event_loop_group_release(s_node_uv_elg);
 
-    // aws_thread_join_all_managed();
+    aws_thread_join_all_managed();
 
     struct aws_napi_context *ctx = user_data;
     aws_napi_logger_destroy(ctx->logger);

--- a/source/module.c
+++ b/source/module.c
@@ -368,8 +368,6 @@ napi_status aws_napi_dispatch_threadsafe_function(
     });
     /* Must always decrement the ref count, or the function will be pinned */
     napi_status release_status = napi_release_threadsafe_function(tsfn, napi_tsfn_release);
-    /* main thread can exit now */
-    AWS_NAPI_ENSURE(env, napi_unref_threadsafe_function(env, tsfn));
     return (call_status != napi_ok) ? call_status : release_status;
 }
 
@@ -384,10 +382,16 @@ napi_status aws_napi_create_threadsafe_function(
     napi_value resource_name = NULL;
     AWS_NAPI_ENSURE(env, napi_create_string_utf8(env, name, NAPI_AUTO_LENGTH, &resource_name));
 
-    AWS_NAPI_CALL(
-        env,
-        napi_create_threadsafe_function(env, function, NULL, resource_name, 0, 1, NULL, NULL, context, call_js, result),
-        { return status; });
+    return napi_create_threadsafe_function(
+        env, function, NULL, resource_name, 0, 1, NULL, NULL, context, call_js, result);
+}
+
+napi_status aws_napi_release_threadsafe_function(
+    napi_threadsafe_function function,
+    napi_threadsafe_function_release_mode mode) {
+    if (function) {
+        return napi_release_threadsafe_function(function, mode);
+    }
     return napi_ok;
 }
 

--- a/source/module.h
+++ b/source/module.h
@@ -60,6 +60,8 @@ napi_status aws_napi_dispatch_threadsafe_function(
 /**
  * Wrapper around napi_create_threadsafe_function,
  * aws_napi_release_threadsafe_function needed to clean up the threadsafe function
+ * Note: If you want to release a thread safe function from within that thread safe function's callback, call unref
+ * instead, and the function will be finalized later by the environment.
  */
 napi_status aws_napi_create_threadsafe_function(
     napi_env env,

--- a/source/module.h
+++ b/source/module.h
@@ -59,7 +59,7 @@ napi_status aws_napi_dispatch_threadsafe_function(
 
 /**
  * Wrapper around napi_create_threadsafe_function,
- * the theadsafe function needed to be released to clean up correctly
+ * aws_napi_release_threadsafe_function needed to clean up the threadsafe function
  */
 napi_status aws_napi_create_threadsafe_function(
     napi_env env,
@@ -71,7 +71,7 @@ napi_status aws_napi_create_threadsafe_function(
 
 /**
  * Wrapper around napi_release_threadsafe_function,
- * check the function before release it.
+ * check the function before releasing it.
  */
 napi_status aws_napi_release_threadsafe_function(
     napi_threadsafe_function function,

--- a/source/module.h
+++ b/source/module.h
@@ -58,8 +58,8 @@ napi_status aws_napi_dispatch_threadsafe_function(
     napi_value *argv);
 
 /**
- * Wrapper around napi_create_threadsafe_function that ensures it is a weak reference and cleans
- * up when the last node reference is cleared.
+ * Wrapper around napi_create_threadsafe_function,
+ * the theadsafe function needed to be released to clean up correctly
  */
 napi_status aws_napi_create_threadsafe_function(
     napi_env env,
@@ -68,6 +68,14 @@ napi_status aws_napi_create_threadsafe_function(
     napi_threadsafe_function_call_js call_js,
     void *context,
     napi_threadsafe_function *result);
+
+/**
+ * Wrapper around napi_release_threadsafe_function,
+ * check the function before release it.
+ */
+napi_status aws_napi_release_threadsafe_function(
+    napi_threadsafe_function function,
+    napi_threadsafe_function_release_mode mode);
 
 /**
  * Wrapper around napi_call_threadsafe_function that always queues (napi_tsfn_nonblocking)

--- a/source/module.h
+++ b/source/module.h
@@ -78,6 +78,13 @@ napi_status aws_napi_release_threadsafe_function(
     napi_threadsafe_function_release_mode mode);
 
 /**
+ * Wrapper around napi_unref_threadsafe_function,
+ * Incase release the threadsafe function from that function is needed, unref will let env go
+ * and the function will be cleaned up as env clean itself up
+ */
+napi_status aws_napi_unref_threadsafe_function(napi_env env, napi_threadsafe_function function);
+
+/**
  * Wrapper around napi_call_threadsafe_function that always queues (napi_tsfn_nonblocking)
  * and pins the function reference until the call completes
  */

--- a/source/mqtt_client_connection.c
+++ b/source/mqtt_client_connection.c
@@ -41,6 +41,7 @@ struct mqtt_connection_binding {
 
 static void s_mqtt_client_connection_finalize(napi_env env, void *finalize_data, void *finalize_hint) {
     (void)finalize_hint;
+    (void)env;
     struct mqtt_connection_binding *binding = finalize_data;
 
     if (binding->use_tls_options) {
@@ -49,10 +50,10 @@ static void s_mqtt_client_connection_finalize(napi_env env, void *finalize_data,
     if (binding->connection) {
         aws_mqtt_client_connection_release(binding->connection);
     }
-    AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->on_connection_interrupted, napi_tsfn_abort));
-    AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->on_connection_resumed, napi_tsfn_abort));
-    AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->on_any_publish, napi_tsfn_abort));
-    AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->transform_websocket, napi_tsfn_abort));
+    // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(binding->on_connection_interrupted, napi_tsfn_abort));
+    // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(binding->on_connection_resumed, napi_tsfn_abort));
+    // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(binding->on_any_publish, napi_tsfn_abort));
+    // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(binding->transform_websocket, napi_tsfn_abort));
 
     aws_mem_release(binding->allocator, binding);
 }
@@ -445,7 +446,7 @@ static void s_on_connect_call(napi_env env, napi_value on_connect, void *context
     AWS_NAPI_ENSURE(
         env, aws_napi_dispatch_threadsafe_function(env, args->on_connect, NULL, on_connect, num_params, params));
 
-    AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(args->on_connect, napi_tsfn_abort));
+    // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(args->on_connect, napi_tsfn_abort));
     aws_mem_release(binding->allocator, args);
 }
 
@@ -695,7 +696,7 @@ cleanup:
     aws_byte_buf_clean_up(&server_name);
 
     if (!success && on_connect_args) {
-        AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(on_connect_args->on_connect, napi_tsfn_abort));
+        // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(on_connect_args->on_connect, napi_tsfn_abort));
         aws_mem_release(binding->allocator, on_connect_args);
     }
 
@@ -779,7 +780,7 @@ static void s_on_publish_complete_call(napi_env env, napi_value on_publish, void
     AWS_NAPI_ENSURE(
         env, aws_napi_dispatch_threadsafe_function(env, args->on_publish, NULL, on_publish, num_params, params));
 
-    AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(args->on_publish, napi_tsfn_abort));
+    // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(args->on_publish, napi_tsfn_abort));
     aws_mem_release(binding->allocator, args);
 }
 
@@ -876,7 +877,7 @@ napi_value aws_napi_mqtt_client_connection_publish(napi_env env, napi_callback_i
         binding->connection, &topic_cur, qos, retain, &payload_cur, s_on_publish_complete, args);
     if (!pub_id) {
         aws_napi_throw_last_error(env);
-        AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(args->on_publish, napi_tsfn_abort));
+        // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(args->on_publish, napi_tsfn_abort));
         goto cleanup;
     }
 
@@ -916,7 +917,7 @@ static void s_on_suback_call(napi_env env, napi_value on_suback, void *context, 
 
     AWS_NAPI_ENSURE(
         env, aws_napi_dispatch_threadsafe_function(env, args->on_suback, NULL, on_suback, num_params, params));
-    AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(args->on_suback, napi_tsfn_abort));
+    // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(args->on_suback, napi_tsfn_abort));
     aws_mem_release(binding->allocator, args);
 }
 
@@ -1117,8 +1118,8 @@ cleanup:
     if (sub->topic.buffer) {
         aws_byte_buf_clean_up(&sub->topic);
     }
-    AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(sub->on_publish, napi_tsfn_abort));
-    AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(suback->on_suback, napi_tsfn_abort));
+    // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(sub->on_publish, napi_tsfn_abort));
+    // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(suback->on_suback, napi_tsfn_abort));
     aws_mem_release(binding->allocator, sub);
     aws_mem_release(binding->allocator, suback);
 
@@ -1335,7 +1336,7 @@ napi_value aws_napi_mqtt_client_connection_unsubscribe(napi_env env, napi_callba
     return NULL;
 cleanup:
     aws_byte_buf_clean_up(&args->topic);
-    AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(args->on_unsuback, napi_tsfn_abort));
+    // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(args->on_unsuback, napi_tsfn_abort));
     aws_mem_release(binding->allocator, args);
 
     return NULL;
@@ -1354,7 +1355,7 @@ static void s_on_disconnect_call(napi_env env, napi_value on_disconnect, void *c
     struct mqtt_connection_binding *binding = context;
 
     AWS_NAPI_ENSURE(env, aws_napi_dispatch_threadsafe_function(env, args->on_disconnect, NULL, on_disconnect, 0, NULL));
-    AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(args->on_disconnect, napi_tsfn_abort));
+    // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(args->on_disconnect, napi_tsfn_abort));
 
     aws_mem_release(binding->allocator, args);
 }
@@ -1413,7 +1414,7 @@ napi_value aws_napi_mqtt_client_connection_disconnect(napi_env env, napi_callbac
 
     if (aws_mqtt_client_connection_disconnect(binding->connection, s_on_disconnected, args)) {
         aws_napi_throw_last_error(env);
-        AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(args->on_disconnect, napi_tsfn_abort));
+        // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(args->on_disconnect, napi_tsfn_abort));
         aws_mem_release(binding->allocator, args);
         return NULL;
     }

--- a/source/mqtt_client_connection.c
+++ b/source/mqtt_client_connection.c
@@ -876,6 +876,7 @@ napi_value aws_napi_mqtt_client_connection_publish(napi_env env, napi_callback_i
         binding->connection, &topic_cur, qos, retain, &payload_cur, s_on_publish_complete, args);
     if (!pub_id) {
         aws_napi_throw_last_error(env);
+        AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(args->on_publish, napi_tsfn_abort));
         goto cleanup;
     }
 
@@ -884,7 +885,6 @@ napi_value aws_napi_mqtt_client_connection_publish(napi_env env, napi_callback_i
 cleanup:
     aws_byte_buf_clean_up(&args->payload);
     aws_byte_buf_clean_up(&args->topic);
-    AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(args->on_publish, napi_tsfn_abort));
     aws_mem_release(allocator, args);
 
     return NULL;

--- a/source/mqtt_client_connection.c
+++ b/source/mqtt_client_connection.c
@@ -50,10 +50,10 @@ static void s_mqtt_client_connection_finalize(napi_env env, void *finalize_data,
     if (binding->connection) {
         aws_mqtt_client_connection_release(binding->connection);
     }
-    // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(binding->on_connection_interrupted, napi_tsfn_abort));
-    // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(binding->on_connection_resumed, napi_tsfn_abort));
-    // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(binding->on_any_publish, napi_tsfn_abort));
-    // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(binding->transform_websocket, napi_tsfn_abort));
+    AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->on_connection_interrupted, napi_tsfn_abort));
+    AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->on_connection_resumed, napi_tsfn_abort));
+    AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->on_any_publish, napi_tsfn_abort));
+    AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->transform_websocket, napi_tsfn_abort));
 
     aws_mem_release(binding->allocator, binding);
 }
@@ -446,7 +446,7 @@ static void s_on_connect_call(napi_env env, napi_value on_connect, void *context
     AWS_NAPI_ENSURE(
         env, aws_napi_dispatch_threadsafe_function(env, args->on_connect, NULL, on_connect, num_params, params));
 
-    // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(args->on_connect, napi_tsfn_abort));
+    AWS_NAPI_ENSURE(env, aws_napi_unref_threadsafe_function(env, args->on_connect));
     aws_mem_release(binding->allocator, args);
 }
 
@@ -696,7 +696,7 @@ cleanup:
     aws_byte_buf_clean_up(&server_name);
 
     if (!success && on_connect_args) {
-        // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(on_connect_args->on_connect, napi_tsfn_abort));
+        AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(on_connect_args->on_connect, napi_tsfn_abort));
         aws_mem_release(binding->allocator, on_connect_args);
     }
 
@@ -780,7 +780,7 @@ static void s_on_publish_complete_call(napi_env env, napi_value on_publish, void
     AWS_NAPI_ENSURE(
         env, aws_napi_dispatch_threadsafe_function(env, args->on_publish, NULL, on_publish, num_params, params));
 
-    // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(args->on_publish, napi_tsfn_abort));
+    AWS_NAPI_ENSURE(env, aws_napi_unref_threadsafe_function(env, args->on_publish));
     aws_mem_release(binding->allocator, args);
 }
 
@@ -877,7 +877,7 @@ napi_value aws_napi_mqtt_client_connection_publish(napi_env env, napi_callback_i
         binding->connection, &topic_cur, qos, retain, &payload_cur, s_on_publish_complete, args);
     if (!pub_id) {
         aws_napi_throw_last_error(env);
-        // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(args->on_publish, napi_tsfn_abort));
+        AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(args->on_publish, napi_tsfn_abort));
         goto cleanup;
     }
 
@@ -917,7 +917,7 @@ static void s_on_suback_call(napi_env env, napi_value on_suback, void *context, 
 
     AWS_NAPI_ENSURE(
         env, aws_napi_dispatch_threadsafe_function(env, args->on_suback, NULL, on_suback, num_params, params));
-    // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(args->on_suback, napi_tsfn_abort));
+    AWS_NAPI_ENSURE(env, aws_napi_unref_threadsafe_function(env, args->on_suback));
     aws_mem_release(binding->allocator, args);
 }
 
@@ -1118,8 +1118,8 @@ cleanup:
     if (sub->topic.buffer) {
         aws_byte_buf_clean_up(&sub->topic);
     }
-    // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(sub->on_publish, napi_tsfn_abort));
-    // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(suback->on_suback, napi_tsfn_abort));
+    AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(sub->on_publish, napi_tsfn_abort));
+    AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(suback->on_suback, napi_tsfn_abort));
     aws_mem_release(binding->allocator, sub);
     aws_mem_release(binding->allocator, suback);
 
@@ -1336,7 +1336,7 @@ napi_value aws_napi_mqtt_client_connection_unsubscribe(napi_env env, napi_callba
     return NULL;
 cleanup:
     aws_byte_buf_clean_up(&args->topic);
-    // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(args->on_unsuback, napi_tsfn_abort));
+    AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(args->on_unsuback, napi_tsfn_abort));
     aws_mem_release(binding->allocator, args);
 
     return NULL;
@@ -1355,7 +1355,7 @@ static void s_on_disconnect_call(napi_env env, napi_value on_disconnect, void *c
     struct mqtt_connection_binding *binding = context;
 
     AWS_NAPI_ENSURE(env, aws_napi_dispatch_threadsafe_function(env, args->on_disconnect, NULL, on_disconnect, 0, NULL));
-    // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(args->on_disconnect, napi_tsfn_abort));
+    AWS_NAPI_ENSURE(env, aws_napi_unref_threadsafe_function(env, args->on_disconnect));
 
     aws_mem_release(binding->allocator, args);
 }
@@ -1414,7 +1414,7 @@ napi_value aws_napi_mqtt_client_connection_disconnect(napi_env env, napi_callbac
 
     if (aws_mqtt_client_connection_disconnect(binding->connection, s_on_disconnected, args)) {
         aws_napi_throw_last_error(env);
-        // AWS_NAPI_ENSURE\(env, aws_napi_release_threadsafe_function(args->on_disconnect, napi_tsfn_abort));
+        AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(args->on_disconnect, napi_tsfn_abort));
         aws_mem_release(binding->allocator, args);
         return NULL;
     }


### PR DESCRIPTION
*Issue #, if available:*
Probably related to issues that crash from an async callback, with stacktrace saying napi_call failed from callback. Since the env may exit before the async callback and fail all the napi_calls
- https://github.com/aws/aws-iot-device-sdk-js-v2/issues/96

The fix of previous issue leads to multiple underlying issues:
- We created an eventloop-group for node, but we never clean it up, so, we will actually result in some leak
- We are using event emitter to invoke the callback, which may lead to an asynced write operation, so, if we clean up the underlying resource right after the callback, we may crash. Instead, using the finalizer to clean up the resource.

*Description of changes:*

Refering: https://nodejs.org/api/n-api.html#n_api_asynchronous_thread_safe_function_calls

> napi_unref_threadsafe_function
> This API is used to indicate that the event loop running on the main thread may exit before func is destroyed. Similar to uv_unref it is also idempotent.

- `napi_unref_threadsafe_function` will not keep env alive, so, when the callback invoked for nodejs, the env maybe invalid, and causing a crash
- Removed the unref stuff and now we need to manually release the thread_safe function to clean it up correctly. Added it for all those thread-safe function I found.
- No need to check the env, it's supposed to be valid, if not, we just screwed it up.
- Interesting finding: If `napi_release_threadsafe_function` called from the threadsafe function, we will end up with weird crash, so, instead of release, we try to use unref for those case. (I know it's hacky and weird.) But due to my experiment, that as the env cleans itself up, the threadsafe function will be finalized as well! So, I think it's not a bad solution.
- Running elasticurl in CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
