### PR TITLE
Accept Uint8Array MQTT payloads

### DIFF
--- a/lib/browser/mqtt.ts
+++ b/lib/browser/mqtt.ts
@@ -137,19 +137,22 @@ class TopicTrie extends Trie<OnMessageCallback | undefined> {
 }
 
 /**
- * Converts payload to a string regardless of the supplied type
+ * Converts payload to string or buffer regardless of the supplied type
  * @param payload The payload to convert
  * @internal
  */
-function normalize_payload(payload: Payload): string {
-    let payload_data: string = payload.toString();
+function normalize_payload(payload: Payload) : Buffer | string {
     if (payload instanceof DataView) {
-        payload_data = new TextDecoder('utf8').decode(payload as DataView);
-    } else if (payload instanceof Object) {
-        // Convert payload to JSON string
-        payload_data = JSON.stringify(payload);
+        return Buffer.from(payload.buffer, payload.byteOffset, payload.byteLength);
     }
-    return payload_data;
+    if (typeof payload === 'string') {
+        return payload;
+    }
+    if (typeof payload === 'object') {
+        // Convert payload to JSON string
+        return JSON.stringify(payload);
+    }
+    throw new TypeError("payload parameter must be a string, object, or DataView.");
 }
 
 /**

--- a/lib/browser/mqtt.ts
+++ b/lib/browser/mqtt.ts
@@ -137,19 +137,26 @@ class TopicTrie extends Trie<OnMessageCallback | undefined> {
 }
 
 /**
- * Converts payload to string or buffer regardless of the supplied type
+ * Converts payload to Buffer or string regardless of the supplied type
  * @param payload The payload to convert
  * @internal
  */
 function normalize_payload(payload: Payload) : Buffer | string {
-    if (payload instanceof DataView) {
-        return Buffer.from(payload.buffer, payload.byteOffset, payload.byteLength);
-    }
-    if (typeof payload === 'string') {
+    if (payload instanceof Buffer) {
+        // pass Buffer through
         return payload;
     }
+    if (typeof payload === 'string') {
+        // pass string through
+        return payload;
+    }
+    if (ArrayBuffer.isView(payload)) {
+        // return Buffer with view upon the same bytes (no copy)
+        const view = payload as ArrayBufferView;
+        return Buffer.from(view.buffer, view.byteOffset, view.byteLength);
+    }
     if (typeof payload === 'object') {
-        // Convert payload to JSON string
+        // Convert Object to JSON string
         return JSON.stringify(payload);
     }
     throw new TypeError("payload parameter must be a string, object, or DataView.");

--- a/lib/common/mqtt.spec.ts
+++ b/lib/common/mqtt.spec.ts
@@ -231,6 +231,10 @@ test('MQTT payload types', async (done) => {
                 send: new DataView(encoder.encode('I was a DataView').buffer),
                 recv: encoder.encode('I was a DataView').buffer,
             },
+            [`/test/types/${id}/uint8array`]: {
+                send: new Uint8Array([0, 1, 255]),
+                recv: new Uint8Array([0, 1, 255]).buffer,
+            },
             [`/test/types/${id}/json`]: {
                 send: { I: "was JSON" },
                 recv: encoder.encode('{"I": "was JSON"}').buffer,

--- a/lib/common/mqtt.spec.ts
+++ b/lib/common/mqtt.spec.ts
@@ -8,7 +8,7 @@ import { v4 as uuid } from 'uuid';
 import { ClientBootstrap } from '@awscrt/io';
 import { MqttClient, QoS, MqttWill } from '@awscrt/mqtt';
 import { AwsIotMqttConnectionConfigBuilder } from '@awscrt/aws_iot';
-import { TextDecoder } from '@awscrt/polyfills';
+import { TextDecoder, TextEncoder } from '@awscrt/polyfills';
 import { Config, fetch_credentials } from '@test/credentials';
 
 jest.setTimeout(10000);

--- a/lib/common/mqtt.spec.ts
+++ b/lib/common/mqtt.spec.ts
@@ -73,7 +73,7 @@ test('MQTT Pub/Sub', async (done) => {
     const promise = new Promise(async (resolve, reject) => {
         connection.on('connect', async (session_present) => {
             expect(session_present).toBeFalsy();
-            const test_topic = '/test/me/senpai';
+            const test_topic = `/test/me/senpai/${uuid()}`;
             const test_payload = 'NOTICE ME';
             const sub = connection.subscribe(test_topic, QoS.AtLeastOnce, async (topic, payload, dup, qos, retain) => {
                 expect(topic).toEqual(test_topic);
@@ -162,7 +162,7 @@ test('MQTT On Any Publish', async (done) => {
     const client = new MqttClient(new ClientBootstrap());
     const connection = client.new_connection(config);
     const promise = new Promise(async (resolve, reject) => {
-        const test_topic = '/test/me/senpai';
+        const test_topic = `/test/me/senpai/${uuid()}`;
         const test_payload = 'NOTICE ME';
 
         connection.on('message', async (topic, payload, dup, qos, retain) => {
@@ -195,6 +195,87 @@ test('MQTT On Any Publish', async (done) => {
 
         const pub = connection.publish(test_topic, test_payload, QoS.AtLeastOnce);
         await expect(pub).resolves.toBeTruthy();
+    });
+    await expect(promise).resolves.toBeTruthy();
+    done();
+});
+
+test('MQTT payload types', async (done) => {
+    let aws_opts: Config;
+    try {
+        aws_opts = await fetch_credentials();
+    } catch (err) {
+        done(err);
+        return;
+    }
+
+    const config = AwsIotMqttConnectionConfigBuilder.new_mtls_builder(aws_opts.certificate, aws_opts.private_key)
+        .with_clean_session(true)
+        .with_client_id(`node-mqtt-unit-test-${uuid()}`)
+        .with_endpoint(aws_opts.endpoint)
+        .with_credentials(Config.region, aws_opts.access_key, aws_opts.secret_key, aws_opts.session_token)
+        .with_timeout_ms(5000)
+        .build()
+    const client = new MqttClient(new ClientBootstrap());
+    const connection = client.new_connection(config);
+    const promise = new Promise(async (resolve, reject) => {
+        const encoder = new TextEncoder();
+        const id = uuid();
+
+        const tests = {
+            [`/test/types/${id}/string`]: {
+                send: 'utf-8 👁👄👁 time',
+                recv: encoder.encode('utf-8 👁👄👁 time').buffer,
+            },
+            [`/test/types/${id}/dataview`]: {
+                send: new DataView(encoder.encode('I was a DataView').buffer),
+                recv: encoder.encode('I was a DataView').buffer,
+            },
+            [`/test/types/${id}/json`]: {
+                send: { I: "was JSON" },
+                recv: encoder.encode('{"I": "was JSON"}').buffer,
+            },
+        }
+
+        // as messages are received, delete items.
+        // when this object is empty all expected messages have been received.
+        let expecting: { [key: string]: ArrayBuffer } = {}
+        for (const topic in tests) {
+            expecting[topic] = tests[topic].recv;
+        }
+
+        connection.on('message', async (topic, payload, dup, qos, retain) => {
+            // QoS1 message might arrive multiple times.
+            // so it's no big deal if we've already seen this topic
+            if (!(topic in expecting)) {
+                return;
+            }
+
+            expect(payload).toEqual(expecting[topic]);
+            delete expecting[topic];
+
+            if (Object.keys(expecting).length == 0) {
+                resolve(true);
+
+                const disconnected = connection.disconnect();
+                await expect(disconnected).resolves.toBeUndefined();
+            }
+        });
+
+        connection.on('error', (error) => {
+            reject(error);
+        });
+        const connected = connection.connect();
+        await expect(connected).resolves.toBeDefined();
+
+        // Subscribe with wildcard
+        const sub = connection.subscribe(`/test/types/${id}/#`, QoS.AtLeastOnce);
+        await expect(sub).resolves.toBeTruthy();
+
+        for (const topic in tests) {
+            const pub = connection.publish(topic, tests[topic].send, QoS.AtLeastOnce);
+            await expect(pub).resolves.toBeTruthy();
+        }
     });
     await expect(promise).resolves.toBeTruthy();
     done();

--- a/lib/common/mqtt.ts
+++ b/lib/common/mqtt.ts
@@ -47,7 +47,7 @@ export enum QoS {
  * @module aws-crt
  * @category MQTT
  */
-export type Payload = string | Object | ArrayBufferView;
+export type Payload = string | Record<string, unknown> | ArrayBufferView;
 
 /**
  * Function called upon receipt of a Publish message on a subscribed topic.

--- a/lib/common/mqtt.ts
+++ b/lib/common/mqtt.ts
@@ -43,7 +43,7 @@ export enum QoS {
  * @module aws-crt
  * @category MQTT
  */
-export type Payload = String | Object | DataView;
+export type Payload = string | Object | DataView;
 
 /**
  * Function called upon receipt of a Publish message on a subscribed topic.

--- a/lib/common/mqtt.ts
+++ b/lib/common/mqtt.ts
@@ -38,12 +38,16 @@ export enum QoS {
 }
 
 /**
- * Possible types of data to send via publish
+ * Possible types of data to send via publish.
+ *
+ * An ArrayBufferView (DataView, Uint8Array, etc) will send its bytes without transformation.
+ * A String will be sent with utf-8 encoding.
+ * An Object will be sent as a JSON string with utf-8 encoding.
  *
  * @module aws-crt
  * @category MQTT
  */
-export type Payload = string | Object | DataView;
+export type Payload = string | Object | ArrayBufferView;
 
 /**
  * Function called upon receipt of a Publish message on a subscribed topic.

--- a/lib/native/binding.d.ts
+++ b/lib/native/binding.d.ts
@@ -15,7 +15,7 @@ import { OnMessageCallback, QoS } from "lib/common/mqtt";
 type NativeHandle = any;
 
 /** @category System */
-type StringLike = string | ArrayBuffer | DataView;
+type StringLike = string | ArrayBuffer | ArrayBufferView;
 
 /* common */
 /** @internal */
@@ -120,7 +120,7 @@ export function mqtt_client_connection_new(
     on_interrupted?: (error_code: number) => void,
     on_resumed?: (return_code: number, session_present: boolean) => void,
     tls_ctx?: NativeHandle,
-    will?: { topic: StringLike, payload: String | Object | DataView, qos: number, retain: boolean },
+    will?: { topic: StringLike, payload: StringLike, qos: number, retain: boolean },
     username?: StringLike,
     password?: StringLike,
     use_websocket?: boolean,

--- a/lib/native/mqtt.ts
+++ b/lib/native/mqtt.ts
@@ -114,9 +114,9 @@ export interface MqttConnectionConfig {
 
 /** @internal */
 function normalize_payload(payload: Payload) : StringLike {
-    if (payload instanceof DataView) {
-        // native can use DataView bytes directly
-        return payload;
+    if (ArrayBuffer.isView(payload)) {
+        // native can use ArrayBufferView bytes directly
+        return payload as ArrayBufferView;
     }
     if (typeof payload === 'string') {
         // native will convert string to utf-8

--- a/source/mqtt_client_connection.c
+++ b/source/mqtt_client_connection.c
@@ -849,7 +849,7 @@ napi_value aws_napi_mqtt_client_connection_publish(napi_env env, napi_callback_i
 
     napi_value node_payload = *arg++;
     AWS_NAPI_CALL(env, aws_byte_buf_init_from_napi(&args->payload, env, node_payload), {
-        napi_throw_type_error(env, NULL, "payload must be a String");
+        napi_throw_type_error(env, NULL, "payload is invalid type");
         goto cleanup;
     });
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-crt-nodejs/issues/171

*Description of changes:*
- Accept any `ArrayBufferView` type (ex: `Uint8Array`). Previously we only accepted `DataView`.
- Fix bug in browser normalize_payload() that assumed a DataView was text.
- Add regression test that sends different payload types.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
