### PR TITLE
Add ArrayBuffer to supported MQTT payload types.

### DIFF
--- a/lib/browser/mqtt.ts
+++ b/lib/browser/mqtt.ts
@@ -141,7 +141,7 @@ class TopicTrie extends Trie<OnMessageCallback | undefined> {
  * @param payload The payload to convert
  * @internal
  */
-function normalize_payload(payload: Payload) : Buffer | string {
+function normalize_payload(payload: Payload): Buffer | string {
     if (payload instanceof Buffer) {
         // pass Buffer through
         return payload;
@@ -154,6 +154,10 @@ function normalize_payload(payload: Payload) : Buffer | string {
         // return Buffer with view upon the same bytes (no copy)
         const view = payload as ArrayBufferView;
         return Buffer.from(view.buffer, view.byteOffset, view.byteLength);
+    }
+    if (payload instanceof ArrayBuffer) {
+        // return Buffer with view upon the same bytes (no copy)
+        return Buffer.from(payload);
     }
     if (typeof payload === 'object') {
         // Convert Object to JSON string
@@ -395,8 +399,8 @@ export class MqttClientConnection extends BufferedEventEmitter {
                 }
                 resolve({
                     packet_id: packet
-                    ? (packet as mqtt.IUnsubackPacket).messageId
-                    : undefined,
+                        ? (packet as mqtt.IUnsubackPacket).messageId
+                        : undefined,
                 });
             });
 

--- a/lib/common/mqtt.ts
+++ b/lib/common/mqtt.ts
@@ -40,6 +40,7 @@ export enum QoS {
 /**
  * Possible types of data to send via publish.
  *
+ * An ArrayBuffer will send its bytes without transformation.
  * An ArrayBufferView (DataView, Uint8Array, etc) will send its bytes without transformation.
  * A String will be sent with utf-8 encoding.
  * An Object will be sent as a JSON string with utf-8 encoding.
@@ -47,7 +48,7 @@ export enum QoS {
  * @module aws-crt
  * @category MQTT
  */
-export type Payload = string | Record<string, unknown> | ArrayBufferView;
+export type Payload = string | Record<string, unknown> | ArrayBuffer | ArrayBufferView;
 
 /**
  * Function called upon receipt of a Publish message on a subscribed topic.

--- a/lib/native/mqtt.ts
+++ b/lib/native/mqtt.ts
@@ -113,10 +113,14 @@ export interface MqttConnectionConfig {
 }
 
 /** @internal */
-function normalize_payload(payload: Payload) : StringLike {
+function normalize_payload(payload: Payload): StringLike {
     if (ArrayBuffer.isView(payload)) {
         // native can use ArrayBufferView bytes directly
         return payload as ArrayBufferView;
+    }
+    if (payload instanceof ArrayBuffer) {
+        // native can use ArrayBuffer bytes directly
+        return payload;
     }
     if (typeof payload === 'string') {
         // native will convert string to utf-8


### PR DESCRIPTION
This fixes aws-iot-device-sdk-js-v2, which shouldn't have been using the `mqtt.Payload` type anyway. But the type-checks used to pass, and now they will again.

Anyway, it's cool to support ArrayBuffer as an outgoing data type. We already supported it under the hood.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
