### PR TITLE
mqtt issue fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1227,7 +1227,7 @@
     "asn1": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha1-jSR136tVO7M+d7VOWeiAu4ziMTY=",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "requires": {
         "safer-buffer": "~2.1.0"
       }
@@ -2615,7 +2615,7 @@
     "form-data": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha1-3M5SwF9kTymManq5Nr1yTO/786Y=",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -5059,7 +5059,7 @@
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA="
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -5635,7 +5635,7 @@
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU="
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -6030,7 +6030,7 @@
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY="
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "querystring": {
       "version": "0.2.0",
@@ -6810,7 +6810,7 @@
     "sshpk": {
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-      "integrity": "sha1-+2YcC+8ps520B2nuOfpwCT1vaHc=",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -7708,7 +7708,7 @@
     "which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "requires": {
         "isexe": "^2.0.0"
       }

--- a/source/class_binder.h
+++ b/source/class_binder.h
@@ -93,6 +93,9 @@ napi_status aws_napi_define_class(
     size_t num_methods,
     struct aws_napi_class_info *class_info);
 
+/* The constructor comes from class info will wrap the native object.
+ * Thus, the finalizer will be invoked with native as
+ * the finalize_data and class_info as the finalize_hint */
 napi_status aws_napi_wrap(
     napi_env env,
     struct aws_napi_class_info *class_info,

--- a/source/mqtt_client_connection.c
+++ b/source/mqtt_client_connection.c
@@ -84,6 +84,9 @@ napi_value aws_napi_mqtt_client_connection_close(napi_env env, napi_callback_inf
         return NULL;
     });
 
+    /* connection has been shutdown, no callbacks will happen after it */
+    s_mqtt_client_connection_release_threadsafe_function(binding);
+
     /* no more node interop will be done, free node resources */
     if (binding->node_external) {
         napi_delete_reference(env, binding->node_external);
@@ -93,8 +96,6 @@ napi_value aws_napi_mqtt_client_connection_close(napi_env env, napi_callback_inf
         aws_mqtt_client_connection_release(binding->connection);
         binding->connection = NULL;
     }
-    /* connection has been shutdown, no callbacks will happen after it */
-    s_mqtt_client_connection_release_threadsafe_function(binding);
 
     return NULL;
 }


### PR DESCRIPTION
*Issue #, if available:*

- pubsub samples from iot-device-sdk-js-v2 exit with non-zero code
- on_publish callback is not cleaned up

*Description of changes:*

- Release the C connection once the `close` called from node, instead of having the same life time with the node object to clean up the subscribe topic tree
- Bug fix: the hint of finalizer is not allocator.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
