### PR TITLE
bug fix

### DIFF
--- a/source/mqtt_client_connection.c
+++ b/source/mqtt_client_connection.c
@@ -46,6 +46,10 @@ static void s_mqtt_client_connection_release_threadsafe_function(struct mqtt_con
         binding->env, aws_napi_release_threadsafe_function(binding->on_connection_resumed, napi_tsfn_abort));
     AWS_NAPI_ENSURE(binding->env, aws_napi_release_threadsafe_function(binding->on_any_publish, napi_tsfn_abort));
     AWS_NAPI_ENSURE(binding->env, aws_napi_release_threadsafe_function(binding->transform_websocket, napi_tsfn_abort));
+    binding->on_connection_interrupted = NULL;
+    binding->on_connection_resumed = NULL;
+    binding->on_any_publish = NULL;
+    binding->transform_websocket = NULL;
 }
 
 static void s_mqtt_client_connection_finalize(napi_env env, void *finalize_data, void *finalize_hint) {
@@ -459,11 +463,12 @@ static void s_on_connect_call(napi_env env, napi_value on_connect, void *context
         env, aws_napi_dispatch_threadsafe_function(env, args->on_connect, NULL, on_connect, num_params, params));
 
     AWS_NAPI_ENSURE(env, aws_napi_unref_threadsafe_function(env, args->on_connect));
-    aws_mem_release(binding->allocator, args);
+
     if (args->return_code || args->error_code) {
         /* Failed to create a connection, none of the callbacks will be invoked again */
         s_mqtt_client_connection_release_threadsafe_function(binding);
     }
+    aws_mem_release(binding->allocator, args);
 }
 
 static void s_on_connected(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Incase the connection failed, then the `disconnect` still invoked.  The `s_mqtt_client_connection_release_threadsafe_function` will be invoked twice.
- use after free bug. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
