### PR TITLE
stop using deprecated aws_off_t

### DIFF
--- a/source/io.c
+++ b/source/io.c
@@ -619,39 +619,35 @@ struct aws_napi_input_stream_impl {
     bool eos;          /* end of stream */
 };
 
-static int s_input_stream_seek(struct aws_input_stream *stream, aws_off_t offset, enum aws_stream_seek_basis basis) {
+static int s_input_stream_seek(struct aws_input_stream *stream, int64_t offset, enum aws_stream_seek_basis basis) {
     struct aws_napi_input_stream_impl *impl = stream->impl;
 
     int result = AWS_OP_SUCCESS;
     uint64_t final_offset = 0;
-    int64_t checked_offset = offset;
 
     aws_mutex_lock(&impl->mutex);
     uint64_t total_bytes = impl->bytes_read + impl->buffer.len;
 
-    switch (basis) {
-        case AWS_SSB_BEGIN:
-            /* Offset must be positive, must be greater than the bytes already read (because those
-             * bytes are gone from the buffer), and must not be greater than the sum of the bytes
-             * read so far and the size of the buffer
-             */
-            if (checked_offset < 0 || (uint64_t)checked_offset > total_bytes ||
-                (uint64_t)checked_offset < impl->bytes_read) {
-                result = AWS_IO_STREAM_INVALID_SEEK_POSITION;
-                goto failed;
-            }
-            final_offset = (uint64_t)checked_offset - impl->bytes_read;
-            break;
-        case AWS_SSB_END:
-            /* Offset must be negative, and must not be trying to go further back than the
-             * current length of the buffer, because those bytes have been purged
-             */
-            if (checked_offset > 0 || checked_offset == INT64_MIN || (uint64_t)(-checked_offset) > impl->buffer.len) {
-                result = AWS_IO_STREAM_INVALID_SEEK_POSITION;
-                goto failed;
-            }
-            final_offset = (uint64_t)impl->buffer.len - (uint64_t)(-checked_offset);
-            break;
+    if (basis == AWS_SSB_BEGIN) {
+        /* Offset must be positive, must be greater than the bytes already read (because those
+         * bytes are gone from the buffer), and must not be greater than the sum of the bytes
+         * read so far and the size of the buffer
+         */
+        if (offset < 0 || (uint64_t)offset > total_bytes || (uint64_t)offset < impl->bytes_read) {
+            result = aws_raise_error(AWS_IO_STREAM_INVALID_SEEK_POSITION);
+            goto failed;
+        }
+        final_offset = (uint64_t)offset - impl->bytes_read;
+    } else {
+        AWS_ASSERT(basis == AWS_SSB_END);
+        /* Offset must be negative, and must not be trying to go further back than the
+         * current length of the buffer, because those bytes have been purged
+         */
+        if (offset > 0 || offset == INT64_MIN || (uint64_t)(-offset) > impl->buffer.len) {
+            result = aws_raise_error(AWS_IO_STREAM_INVALID_SEEK_POSITION);
+            goto failed;
+        }
+        final_offset = (uint64_t)impl->buffer.len - (uint64_t)(-offset);
     }
 
     AWS_ASSERT(final_offset <= SIZE_MAX);


### PR DESCRIPTION
related:
https://github.com/awslabs/aws-c-common/pull/808
https://github.com/awslabs/aws-c-io/pull/386

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
