### PR TITLE
fix webpack build error

### DIFF
--- a/lib/native/binding.js
+++ b/lib/native/binding.js
@@ -36,7 +36,7 @@ const search_paths = [
 
 let binding;
 for (const path of search_paths) {
-    if (existsSync(path + '.node')) {
+    if (path && existsSync(path + '.node')) {
         binding = require(path);
         break;
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The reason for this PR is during my electron build, webpack says the AWS CRT module is not found. 

https://github.com/aws/aws-iot-device-sdk-js-v2/issues/158

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
