### PR TITLE
Updating aws-c-io for OverrideTrustStore log warning

### DIFF
--- a/source/io.c
+++ b/source/io.c
@@ -619,7 +619,7 @@ struct aws_napi_input_stream_impl {
     bool eos;          /* end of stream */
 };
 
-static int s_input_stream_seek(struct aws_input_stream *stream, aws_off_t offset, enum aws_stream_seek_basis basis) {
+static int s_input_stream_seek(struct aws_input_stream *stream, int64_t offset, enum aws_stream_seek_basis basis) {
     struct aws_napi_input_stream_impl *impl = stream->impl;
 
     int result = AWS_OP_SUCCESS;


### PR DESCRIPTION
*Description of changes:*
* Updating aws-c-io for OverrideTrustStore log warning

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
