### PR TITLE
Temporarily revert cmake-js to 6.1 to unblock release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^0.21.1",
-        "cmake-js": "^6.2.0",
+        "cmake-js": "^6.1.0",
         "crypto-js": "^4.0.0",
         "fastestsmallesttextencoderdecoder": "^1.0.22",
         "mqtt": "^4.2.8",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "axios": "^0.21.1",
-    "cmake-js": "^6.2.0",
+    "cmake-js": "^6.1.0",
     "crypto-js": "^4.0.0",
     "fastestsmallesttextencoderdecoder": "^1.0.22",
     "mqtt": "^4.2.8",


### PR DESCRIPTION


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
