### PR TITLE
Split debug info out from node module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,7 @@ add_library(${PROJECT_NAME} SHARED ${AWS_CRT_SRC})
 aws_set_common_properties(${PROJECT_NAME})
 aws_prepare_symbol_visibility_args(${PROJECT_NAME} "AWS_CRT_NODEJS")
 aws_add_sanitizers(${PROJECT_NAME})
+aws_split_debug_info(${PROJECT_NAME})
 
 # Gives our library file a .node extension without any "lib" prefix
 set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "" SUFFIX ".node")


### PR DESCRIPTION
Depends on:
* https://github.com/awslabs/aws-crt-nodejs/pull/248

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
