### PR TITLE
Landing page for browser/node documentation split

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,12 +3,11 @@
 <head>
     <meta charset="UTF-8">
     <title>AWS CRT for Javascript</title>
-    <h1>AWS CRT for Javascript</h1>
-    <p>While the overall interfaces for MQTT and HTTP are kept relatively in sync, the node and browser flavors of the AWS CRT have different capabilities.  For this reason, we generate separate documentation for each flavor.</p>
-    <a href="./node/index.html"><h3>Node Documentation</h3></a>
-    <a href="./browser/index.html"><h3>Browser Documentation</h3></a>
 </head>
 <body>
-
+<h1>AWS CRT for Javascript</h1>
+<p>While the overall interfaces for MQTT and HTTP are kept relatively in sync, the node and browser flavors of the AWS CRT have different capabilities.  For this reason, we generate separate documentation for each flavor.</p>
+<a href="./node/index.html"><h3>Node Documentation</h3></a>
+<a href="./browser/index.html"><h3>Browser Documentation</h3></a>
 </body>
 </html>


### PR DESCRIPTION
Adds a landing page under docs/ for the separate node and browser documentation sets.  Github only allows the root or docs/ to be the page landing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
