### PR TITLE
Add napi env checks where appropriate to native-to-node function calls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -471,9 +471,9 @@
       "dev": true
     },
     "@hapi/hoek": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
-      "integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.1.tgz",
+      "integrity": "sha512-gfta+H8aziZsm8pZa0vj04KO6biEiisppNgA1kbJvFrrWu9Vm7eaUEy76DIxsuTaWvti5fkJVhllWc6ZTE+Mdw==",
       "dev": true
     },
     "@hapi/topo": {
@@ -808,9 +808,9 @@
       }
     },
     "@sideway/address": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.2.tgz",
-      "integrity": "sha512-idTz8ibqWFrPU8kMirL0CoPH/A29XOzzAzpyN3zQ4kAWnzmNfFmRaoMNN6VI8ske5M73HZyhIaW4OuSFIdM4oA==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.3.tgz",
+      "integrity": "sha512-8ncEUtmnTsMmL7z1YPB47kPUq7LpKWJNFPsRzHiIajGC5uXlWGn+AmkYPcHNl8S4tcEGx+cnORnNYaw2wvL+LQ==",
       "dev": true,
       "requires": {
         "@hapi/hoek": "^9.0.0"
@@ -1385,6 +1385,16 @@
       "dev": true,
       "requires": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "buffer-crc32": {
@@ -2220,9 +2230,9 @@
       }
     },
     "find-process": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/find-process/-/find-process-1.4.4.tgz",
-      "integrity": "sha512-rRSuT1LE4b+BFK588D2V8/VG9liW0Ark1XJgroxZXI0LtwmQJOb490DvDYvbm+Hek9ETFzTutGfJ90gumITPhQ==",
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/find-process/-/find-process-1.4.7.tgz",
+      "integrity": "sha512-/U4CYp1214Xrp3u3Fqr9yNynUrr5Le4y0SsJh2lMDDSbpwYSz3M2SMWQC+wqcx79cN8PQtHQIL8KnuY9M66fdg==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
@@ -3530,14 +3540,14 @@
       "dev": true
     },
     "joi": {
-      "version": "17.4.2",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.4.2.tgz",
-      "integrity": "sha512-Lm56PP+n0+Z2A2rfRvsfWVDXGEWjXxatPopkQ8qQ5mxCEhwHG+Ettgg5o98FFaxilOxozoa14cFhrE/hOzh/Nw==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.5.0.tgz",
+      "integrity": "sha512-R7hR50COp7StzLnDi4ywOXHrBrgNXuUUfJWIR5lPY5Bm/pOD3jZaTwpluUXVLRWcoWZxkrHBBJ5hLxgnlehbdw==",
       "dev": true,
       "requires": {
         "@hapi/hoek": "^9.0.0",
         "@hapi/topo": "^5.0.0",
-        "@sideway/address": "^4.1.0",
+        "@sideway/address": "^4.1.3",
         "@sideway/formula": "^3.0.0",
         "@sideway/pinpoint": "^2.0.0"
       }
@@ -3833,9 +3843,9 @@
       }
     },
     "mime": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
-      "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
       "dev": true
     },
     "mime-db": {
@@ -4280,14 +4290,6 @@
         "tar-fs": "^2.0.0",
         "unbzip2-stream": "^1.3.3",
         "ws": "^7.2.3"
-      },
-      "dependencies": {
-        "ws": {
-          "version": "7.5.5",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
-          "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
-          "dev": true
-        }
       }
     },
     "querystring": {
@@ -4998,18 +5000,6 @@
       "requires": {
         "buffer": "^5.2.1",
         "through": "^2.3.8"
-      },
-      "dependencies": {
-        "buffer": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-          "dev": true,
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.1.13"
-          }
-        }
       }
     },
     "universalify": {

--- a/package.json
+++ b/package.json
@@ -23,12 +23,10 @@
     "install": "node ./scripts/install.js"
   },
   "devDependencies": {
-    "typedoc-plugin-external-module-name": "^4.0.6",
-    "typedoc-plugin-remove-references": "^0.0.5",
     "@types/crypto-js": "^3.1.43",
     "@types/jest": "^27.0.1",
     "@types/node": "^10.17.54",
-    "@types/puppeteer": "^5.4.3",
+    "@types/puppeteer": "^5.4.4",
     "@types/uuid": "^3.4.8",
     "@types/ws": "^7.4.7",
     "aws-sdk": "^2.848.0",
@@ -39,6 +37,8 @@
     "ts-jest": "^27.0.5",
     "typedoc": "^0.17.8",
     "typedoc-plugin-as-member-of": "^1.0.2",
+    "typedoc-plugin-external-module-name": "^4.0.6",
+    "typedoc-plugin-remove-references": "^0.0.5",
     "typescript": "^3.9.9",
     "uuid": "^8.3.2",
     "yargs": "^17.2.1"

--- a/source/http_connection.c
+++ b/source/http_connection.c
@@ -192,14 +192,17 @@ static void s_http_on_connection_setup_call(napi_env env, napi_value on_setup, v
     struct http_connection_binding *binding = context;
     struct on_connection_args *args = user_data;
 
-    napi_value params[2];
-    const size_t num_params = AWS_ARRAY_SIZE(params);
+    if (env) {
+        napi_value params[2];
+        const size_t num_params = AWS_ARRAY_SIZE(params);
 
-    AWS_NAPI_ENSURE(env, napi_get_reference_value(env, args->binding->node_external, &params[0]));
-    AWS_NAPI_ENSURE(env, napi_create_uint32(env, args->error_code, &params[1]));
+        AWS_NAPI_ENSURE(env, napi_get_reference_value(env, args->binding->node_external, &params[0]));
+        AWS_NAPI_ENSURE(env, napi_create_uint32(env, args->error_code, &params[1]));
 
-    AWS_NAPI_ENSURE(
-        env, aws_napi_dispatch_threadsafe_function(env, binding->on_setup, NULL, on_setup, num_params, params));
+        AWS_NAPI_ENSURE(
+            env, aws_napi_dispatch_threadsafe_function(env, binding->on_setup, NULL, on_setup, num_params, params));
+    }
+
     AWS_NAPI_ENSURE(env, aws_napi_release_threadsafe_function(binding->on_setup, napi_tsfn_abort));
     if (args->error_code) {
         /* setup failed, shutdown will never get invoked. Clean up the functions here */

--- a/source/http_connection_manager.c
+++ b/source/http_connection_manager.c
@@ -248,18 +248,21 @@ static void s_http_connection_manager_on_acquired_call(
     struct http_connection_manager_binding *binding = context;
     struct connection_acquired_args *args = user_data;
 
-    napi_value connection_external = aws_napi_http_connection_from_manager(env, args->connection);
-    AWS_FATAL_ASSERT(connection_external);
+    if (env) {
+        napi_value connection_external = aws_napi_http_connection_from_manager(env, args->connection);
+        AWS_FATAL_ASSERT(connection_external);
 
-    napi_value params[2];
-    const size_t num_params = AWS_ARRAY_SIZE(params);
-    params[0] = connection_external;
-    AWS_NAPI_ENSURE(env, napi_create_int32(env, args->error_code, &params[1]));
+        napi_value params[2];
+        const size_t num_params = AWS_ARRAY_SIZE(params);
+        params[0] = connection_external;
+        AWS_NAPI_ENSURE(env, napi_create_int32(env, args->error_code, &params[1]));
 
-    AWS_NAPI_ENSURE(
-        env, aws_napi_dispatch_threadsafe_function(env, args->on_acquired, NULL, on_acquired, num_params, params));
+        AWS_NAPI_ENSURE(
+            env, aws_napi_dispatch_threadsafe_function(env, args->on_acquired, NULL, on_acquired, num_params, params));
 
-    AWS_NAPI_ENSURE(env, aws_napi_unref_threadsafe_function(env, args->on_acquired));
+        AWS_NAPI_ENSURE(env, aws_napi_unref_threadsafe_function(env, args->on_acquired));
+    }
+
     aws_mem_release(binding->allocator, args);
 }
 

--- a/source/module.h
+++ b/source/module.h
@@ -19,6 +19,12 @@ struct aws_client_bootstrap;
 struct aws_event_loop;
 struct aws_event_loop_group;
 
+enum aws_crt_nodejs_errors {
+    AWS_CRT_NODEJS_ERROR_THREADSAFE_FUNCTION_NULL_NAPI_ENV = AWS_ERROR_ENUM_BEGIN_RANGE(AWS_CRT_NODEJS_PACKAGE_ID),
+
+    AWS_CRT_NODEJS_ERROR_END_RANGE = AWS_ERROR_ENUM_END_RANGE(AWS_CRT_NODEJS_PACKAGE_ID)
+};
+
 enum aws_napi_log_subject {
     AWS_LS_NODEJS_CRT_GENERAL = AWS_LOG_SUBJECT_BEGIN_RANGE(AWS_CRT_NODEJS_PACKAGE_ID),
 


### PR DESCRIPTION
* Add napi env checks to a number of native-to-node functions
* Error enum for nodejs crt
* Misc. memory cleanup for a few failure paths

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
