### PR TITLE
Fix unresolved promise on disconnect

### DIFF
--- a/lib/browser/mqtt.ts
+++ b/lib/browser/mqtt.ts
@@ -486,7 +486,7 @@ export class MqttClientConnection extends BufferedEventEmitter {
     */
     async disconnect() {
         return new Promise((resolve) => {
-            this.connection.end(null, resolve)
+            this.connection.end(undefined, resolve)
         });
     }
 }

--- a/lib/browser/mqtt.ts
+++ b/lib/browser/mqtt.ts
@@ -486,9 +486,7 @@ export class MqttClientConnection extends BufferedEventEmitter {
     */
     async disconnect() {
         return new Promise((resolve) => {
-            this.connection.end(undefined, undefined, () => {
-                resolve();
-            })
+            this.connection.end(null, resolve)
         });
     }
 }


### PR DESCRIPTION
*Description of changes:*
When calling: `await client.disconnect()` the promise never resolves.

This is due to how the API is a bit misleading on how callbacks are supposed to be passed to the mqtt client:
https://github.com/mqttjs/MQTT.js/blob/master/lib/client.js#L978-L984

This PR fixes the disconnect promise callback


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
