### PR TITLE
Throw exception if the native addon init gets called more than once.

### DIFF
--- a/source/module.c
+++ b/source/module.c
@@ -34,8 +34,11 @@
 
 #include <uv.h>
 
-/* aws-crt-nodejs requires N-API version 4 or above for the threadsafe function API */
-// AWS_STATIC_ASSERT(NAPI_VERSION >= 4);
+
+/*
+ * aws-crt-nodejs requires N-API version 4 or above for the threadsafe function API
+ */
+AWS_STATIC_ASSERT(NAPI_VERSION >= 4);
 
 #define AWS_DEFINE_ERROR_INFO_CRT_NODEJS(CODE, STR) AWS_DEFINE_ERROR_INFO(CODE, STR, "aws-crt-nodejs")
 

--- a/source/module.c
+++ b/source/module.c
@@ -34,8 +34,10 @@
 
 #include <uv.h>
 
-
 /*
+ * This is a multi-line comment to ensure that the static assert does not collide with the static asserts in
+ * aws/common/macro.h.
+ *
  * aws-crt-nodejs requires N-API version 4 or above for the threadsafe function API
  */
 AWS_STATIC_ASSERT(NAPI_VERSION >= 4);
@@ -600,7 +602,7 @@ static bool s_module_initialized = false;
     aws_mutex_unlock(&s_module_lock);
 
     if (already_initialized) {
-        napi_throw_error(env, NULL, "Aws-crt-nodejs does not yet support multi-initialization.  Apologies.");
+        napi_throw_error(env, NULL, "Aws-crt-nodejs does not yet support multi-initialization.");
         return NULL;
     }
 


### PR DESCRIPTION
Better than hard crash.  We must figure out the right way to handle this eventually

https://github.com/awslabs/aws-crt-nodejs/issues/286

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
