### PR TITLE
bump up package size check

### DIFF
--- a/continuous-delivery/pack.sh
+++ b/continuous-delivery/pack.sh
@@ -47,7 +47,7 @@ UNZIP="unzip_pack"
 mkdir $UNZIP
 tar -xf aws-crt-$CURRENT_TAG_VERSION.tgz -C $UNZIP
 PACK_FILE_SIZE_KB=$(du -sk $UNZIP | awk '{print $1}')
-if expr $PACK_FILE_SIZE_KB \> 12000 ; then
+if expr $PACK_FILE_SIZE_KB \> "$((12 * 1024))" ; then
     # the package size is larger than 12 MB, return -1
     echo "Package size is too large"
     exit -1


### PR DESCRIPTION
A release just failed because we were 72 bytes over the cap.

Bump the cap up a smidge so we can release a security fix.

Long term, we should be doing these checks with each commit to main, not as something that fails at release time.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
