### PR TITLE
Support for Apple M1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,12 +100,11 @@ jobs:
         python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
         chmod a+x builder
         ./builder build -p ${{ env.PACKAGE_NAME }} --spec=downstream
-    # check that OSX can build arm64 binaries from an x64 machine
-    # currently, we do this in our release process and we want to be sure it's working
+    # check that OSX can build arm64 binaries from an x64 machine (which happens during release)
     - name: Cross-compile arm64
       run: |
         cd aws-crt-nodejs
-        node ./scripts/build --force-arch arm64
+        node ./scripts/build --target-arch arm64
         test `lipo dist/bin/darwin-arm64/aws-crt-nodejs.node -archs` = "arm64"
         test `lipo dist/bin/darwin-x64/aws-crt-nodejs.node -archs` = "x86_64"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
     - name: Cross-compile arm64
       run: |
         cd aws-crt-nodejs
-        node ./scripts/build --target-arch arm64
+        node ./scripts/build --target-arch arm64 -DAWS_WARNINGS_ARE_ERRORS=ON
         test `lipo dist/bin/darwin-arm64/aws-crt-nodejs.node -archs` = "arm64"
         test `lipo dist/bin/darwin-x64/aws-crt-nodejs.node -archs` = "x86_64"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,15 @@ jobs:
         python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
         chmod a+x builder
         ./builder build -p ${{ env.PACKAGE_NAME }} --spec=downstream
+    # check that OSX can build arm64 binaries from an x64 machine
+    # currently, we do this in our release process and we want to be sure it's working
+    - name: Cross-compile arm64
+      run: |
+        cd aws-crt-nodejs
+        node ./scripts/build --force-arch arm64
+        test `lipo dist/bin/darwin-arm64/aws-crt-nodejs.node -archs` = "arm64"
+        test `lipo dist/bin/darwin-x64/aws-crt-nodejs.node -archs` = "x86_64"
+
 
   # check that docs can still build
   check-docs:

--- a/.npmignore
+++ b/.npmignore
@@ -165,6 +165,7 @@ deps_build/
 **/builder.json
 **/.travis*
 **/.github/
+**/.gitmodules
 **/continuous-delivery/
 **/docs/
 **/docsrc/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,9 +96,9 @@ aws_use_package(aws-c-auth REQUIRED)
 aws_use_package(aws-checksums REQUIRED)
 target_link_libraries(${PROJECT_NAME} PRIVATE ${CMAKE_JS_LIB} ${DEP_AWS_LIBS})
 
-if (CMAKE_JS_PLATFORM AND CMAKE_JS_ARCH)
+if (CMAKE_JS_PLATFORM AND NODE_ARCH)
     # When run from build.ts, these are set
-    set(destination bin/${CMAKE_JS_PLATFORM}-${CMAKE_JS_ARCH})
+    set(destination bin/${CMAKE_JS_PLATFORM}-${NODE_ARCH})
 else()
     # If not, default to "native"
     set(destination bin/native)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,8 +100,7 @@ if (CMAKE_JS_PLATFORM AND NODE_ARCH)
     # When run from build.ts, these are set
     set(destination bin/${CMAKE_JS_PLATFORM}-${NODE_ARCH})
 else()
-    # If not, default to "native"
-    set(destination bin/native)
+    message(FATAL_ERROR "CMAKE_JS_PLATFORM and NODE_ARCH must be set")
 endif()
 
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}/aws-crt-nodejs.node"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,11 @@ cmake_minimum_required(VERSION 3.1)
 project(aws-crt-nodejs C)
 option(BUILD_DEPS "Builds aws common runtime dependencies as part of build, only do this if you don't want to control your dependency chain." ON)
 
+option(CMAKE_JS_PLATFORM "Target platform. Should match node's os.platform()")
+if (NOT CMAKE_JS_PLATFORM)
+    message(FATAL_ERROR "CMAKE_JS_PLATFORM must be set")
+endif()
+
 include(CTest)
 
 # ensure that the release build has symbols
@@ -96,12 +101,7 @@ aws_use_package(aws-c-auth REQUIRED)
 aws_use_package(aws-checksums REQUIRED)
 target_link_libraries(${PROJECT_NAME} PRIVATE ${CMAKE_JS_LIB} ${DEP_AWS_LIBS})
 
-if (CMAKE_JS_PLATFORM AND NODE_ARCH)
-    # When run from build.ts, these are set
-    set(destination bin/${CMAKE_JS_PLATFORM}-${NODE_ARCH})
-else()
-    message(FATAL_ERROR "CMAKE_JS_PLATFORM and NODE_ARCH must be set")
-endif()
+set(destination bin/${CMAKE_JS_PLATFORM}-${NODE_ARCH})
 
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}/aws-crt-nodejs.node"
     DESTINATION ${destination})

--- a/builder.json
+++ b/builder.json
@@ -67,13 +67,8 @@
         ],
         [
             "node",
-            "node_modules/.bin/cmake-js",
-            "compile",
-            "--out={build_dir}",
-            "--DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
-            "--DAWS_WARNINGS_ARE_ERRORS=ON",
-            "-T",
-            "install"
+            "scripts/build.js",
+            "-DAWS_WARNINGS_ARE_ERRORS=ON"
         ],
         [
             "npm",

--- a/builder.json
+++ b/builder.json
@@ -36,15 +36,6 @@
             "x86": {
                 "enabled": false
             }
-        },
-        "windows": {
-            "!build_steps": [
-                [
-                    "npm",
-                    "install",
-                    "--DAWS_WARNINGS_ARE_ERRORS=ON"
-                ]
-            ]
         }
     },
     "upstream": [],

--- a/continuous-delivery/build-binaries-linux-x64.yml
+++ b/continuous-delivery/build-binaries-linux-x64.yml
@@ -5,7 +5,7 @@ phases:
       - mkdir linux-x64
       - cd aws-crt-nodejs
       - builder build --project=aws-crt-nodejs --skip-install run_tests=false
-      - cp -r dist/bin/native/* ../linux-x64/
+      - cp -r dist/bin/linux-x64/* ../linux-x64/
 
 artifacts:
   files:

--- a/continuous-delivery/build-binaries-unix.sh
+++ b/continuous-delivery/build-binaries-unix.sh
@@ -1,2 +1,5 @@
-#!/usr/bin/env bash	
+#!/usr/bin/env bash
+
+set -ex
+
 npm install --unsafe-perm

--- a/continuous-delivery/build-osx-x64-arm64.sh
+++ b/continuous-delivery/build-osx-x64-arm64.sh
@@ -6,4 +6,7 @@ set -ex
 npm install --unsafe-perm
 
 # build arm64
+# NOTE: This is the only build job that compiles for two different architectures.
+# Our release pipeline doesn't currently have an arm64 OSX machine,
+# so we use the x64 OSX machine create both types of binaries.
 node ./scripts/build --force-arch arm64

--- a/continuous-delivery/build-osx-x64-arm64.sh
+++ b/continuous-delivery/build-osx-x64-arm64.sh
@@ -8,5 +8,5 @@ npm install --unsafe-perm
 # build arm64
 # NOTE: This is the only build job that compiles for two different architectures.
 # Our release pipeline doesn't currently have an arm64 OSX machine,
-# so we use the x64 OSX machine create both types of binaries.
+# so we use the x64 OSX machine to create both types of binaries.
 node ./scripts/build --target-arch arm64

--- a/continuous-delivery/build-osx-x64-arm64.sh
+++ b/continuous-delivery/build-osx-x64-arm64.sh
@@ -9,4 +9,4 @@ npm install --unsafe-perm
 # NOTE: This is the only build job that compiles for two different architectures.
 # Our release pipeline doesn't currently have an arm64 OSX machine,
 # so we use the x64 OSX machine create both types of binaries.
-node ./scripts/build --force-arch arm64
+node ./scripts/build --target-arch arm64

--- a/continuous-delivery/build-osx-x64-arm64.sh
+++ b/continuous-delivery/build-osx-x64-arm64.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -ex
+
+# build x64 (assumes we're running on Intel)
+npm install --unsafe-perm
+
+# build arm64
+node ./scripts/build --force-arch arm64

--- a/continuous-delivery/pack.sh
+++ b/continuous-delivery/pack.sh
@@ -1,38 +1,29 @@
 #!/usr/bin/env bash
 set -ex
 
-# force a failure if there's no tag
-git describe --tags
-# now get the tag
+# note: test-version-exists.sh checked that we were ready for release in an earlier pipeline stage
 CURRENT_TAG=$(git describe --tags | cut -f2 -dv)
-# convert v0.2.12-2-g50254a9 to 0.2.12
-CURRENT_TAG_VERSION=$(git describe --tags | cut -f1 -d'-' | cut -f2 -dv)
-# if there's a hash on the tag, then this is not a release tagged commit
-if [ "$CURRENT_TAG" != "$CURRENT_TAG_VERSION" ]; then
-    echo "Current tag version is not a release tag, cut a new release if you want to publish."
-    exit 1
-fi
 
 # go to previous directory
 cd ..
 
 # native source code
-tar -cvzf aws-crt-$CURRENT_TAG_VERSION-source.tgz aws-crt-nodejs/crt
+tar -cvzf aws-crt-$CURRENT_TAG-source.tgz aws-crt-nodejs/crt
 # sha256 checksum
-SOURCE_SHA256=$(sha256sum aws-crt-$CURRENT_TAG_VERSION-source.tgz | awk '{print $1}')
-echo -n $SOURCE_SHA256 > aws-crt-$CURRENT_TAG_VERSION-source.sha256
+SOURCE_SHA256=$(sha256sum aws-crt-$CURRENT_TAG-source.tgz | awk '{print $1}')
+echo -n $SOURCE_SHA256 > aws-crt-$CURRENT_TAG-source.sha256
 
 # omnibus package
-tar -cvzf aws-crt-$CURRENT_TAG_VERSION-all.tgz aws-crt-nodejs/
+tar -cvzf aws-crt-$CURRENT_TAG-all.tgz aws-crt-nodejs/
 # sha256 checksum
-SOURCE_SHA256=$(sha256sum aws-crt-$CURRENT_TAG_VERSION-all.tgz | awk '{print $1}')
-echo -n $SOURCE_SHA256 > aws-crt-$CURRENT_TAG_VERSION-all.sha256
+SOURCE_SHA256=$(sha256sum aws-crt-$CURRENT_TAG-all.tgz | awk '{print $1}')
+echo -n $SOURCE_SHA256 > aws-crt-$CURRENT_TAG-all.sha256
 
 # binaries
-tar -cvzf aws-crt-$CURRENT_TAG_VERSION-binary.tgz aws-crt-nodejs/dist/bin
+tar -cvzf aws-crt-$CURRENT_TAG-binary.tgz aws-crt-nodejs/dist/bin
 # sha256 checksum
-SOURCE_SHA256=$(sha256sum aws-crt-$CURRENT_TAG_VERSION-binary.tgz | awk '{print $1}')
-echo -n $SOURCE_SHA256 > aws-crt-$CURRENT_TAG_VERSION-binary.sha256
+SOURCE_SHA256=$(sha256sum aws-crt-$CURRENT_TAG-binary.tgz | awk '{print $1}')
+echo -n $SOURCE_SHA256 > aws-crt-$CURRENT_TAG-binary.sha256
 
 
 # npm pack
@@ -45,7 +36,7 @@ cp aws-crt-*.tgz ..
 cd ..
 UNZIP="unzip_pack"
 mkdir $UNZIP
-tar -xf aws-crt-$CURRENT_TAG_VERSION.tgz -C $UNZIP
+tar -xf aws-crt-$CURRENT_TAG.tgz -C $UNZIP
 PACK_FILE_SIZE_KB=$(du -sk $UNZIP | awk '{print $1}')
 if expr $PACK_FILE_SIZE_KB \> "$((14 * 1024))" ; then
     # the package size is larger than 14 MB, return -1

--- a/continuous-delivery/pack.sh
+++ b/continuous-delivery/pack.sh
@@ -47,8 +47,8 @@ UNZIP="unzip_pack"
 mkdir $UNZIP
 tar -xf aws-crt-$CURRENT_TAG_VERSION.tgz -C $UNZIP
 PACK_FILE_SIZE_KB=$(du -sk $UNZIP | awk '{print $1}')
-if expr $PACK_FILE_SIZE_KB \> "$((12 * 1024))" ; then
-    # the package size is larger than 12 MB, return -1
+if expr $PACK_FILE_SIZE_KB \> "$((14 * 1024))" ; then
+    # the package size is larger than 14 MB, return -1
     echo "Package size is too large"
     exit -1
 fi

--- a/continuous-delivery/pack.yml
+++ b/continuous-delivery/pack.yml
@@ -12,7 +12,7 @@ phases:
       - export DIST_BIN=dist/bin
       - mkdir -p $DIST_BIN
       - cp -r $CODEBUILD_SRC_DIR_aws_crt_nodejs_linux_x64/* $DIST_BIN
-      - cp -r $CODEBUILD_SRC_DIR_aws_crt_nodejs_osx_x64/* $DIST_BIN
+      - cp -r $CODEBUILD_SRC_DIR_aws_crt_nodejs_osx_x64_arm64/* $DIST_BIN
       - cp -r $CODEBUILD_SRC_DIR_aws_crt_nodejs_win_x64/* $DIST_BIN
       - cp -r $CODEBUILD_SRC_DIR_aws_crt_nodejs_linux_aarch64/* $DIST_BIN
       - ls $DIST_BIN

--- a/continuous-delivery/update-version.sh
+++ b/continuous-delivery/update-version.sh
@@ -1,18 +1,9 @@
 #!/usr/bin/env bash
 set -ex
 
-# force a failure if there's no tag
-git describe --tags
-# now get the tag
+# note: test-version-exists.sh checked that we were ready for release in an earlier pipeline stage
 CURRENT_TAG=$(git describe --tags | cut -f2 -dv)
-# convert v0.2.12-2-g50254a9 to 0.2.12
-CURRENT_TAG_VERSION=$(git describe --tags | cut -f1 -d'-' | cut -f2 -dv)
-# if there's a hash on the tag, then this is not a release tagged commit
-if [ "$CURRENT_TAG" != "$CURRENT_TAG_VERSION" ]; then
-    echo "Current tag version is not a release tag, cut a new release if you want to publish."
-    exit 1
-fi
 
-sed --in-place -E "s/\"version\": \".+\"/\"version\": \"${CURRENT_TAG_VERSION}\"/" package.json
+sed --in-place -E "s/\"version\": \".+\"/\"version\": \"${CURRENT_TAG}\"/" package.json
 
 exit 0

--- a/lib/native/binding.js
+++ b/lib/native/binding.js
@@ -30,7 +30,6 @@ if (existsSync(dist)) {
 const bin_path = path.resolve(source_root, 'bin');
 
 const search_paths = [
-    path.join(bin_path, 'native', binary_name),
     path.join(bin_path, platformDir, binary_name),
 ];
 

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -99,7 +99,8 @@ async function fetchNativeCode(url, version, path) {
 }
 
 function buildLocally() {
-    let arch = os.arch;
+    const platform = os.platform();
+    let arch = os.arch();
 
     // Allow cross-compile (so OSX can do arm64 or x64 builds) via:
     // --target-arch ARCH
@@ -112,19 +113,19 @@ function buildLocally() {
         target: "install",
         debug: process.argv.includes('--debug'),
         arch: arch,
-        out: path.join('build', `${os.platform}-${arch}`),
+        out: path.join('build', `${platform}-${arch}`),
         cMakeOptions: {
             CMAKE_EXPORT_COMPILE_COMMANDS: true,
-            CMAKE_JS_PLATFORM: os.platform,
+            CMAKE_JS_PLATFORM: platform,
             BUILD_TESTING: 'OFF',
             CMAKE_INSTALL_PREFIX: 'crt/install',
             CMAKE_PREFIX_PATH: 'crt/install',
         }
     }
 
-    if (os.platform == 'darwin') {
+    if (platform === 'darwin') {
         // Node calls it "x64" but Apple calls it "x86_64", they both agree on "arm64" though
-        options.cMakeOptions.CMAKE_OSX_ARCHITECTURES = (arch == 'x64') ? 'x86_64' : arch;
+        options.cMakeOptions.CMAKE_OSX_ARCHITECTURES = (arch === 'x64') ? 'x86_64' : arch;
     }
 
     // Convert any -D arguments to this script to cmake -D arguments

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -123,8 +123,13 @@ function buildLocally() {
         }
     }
 
+    // We need to pass some extra flags to pull off cross-compiling
+    // because cmake-js doesn't set everything we need.
+    //
+    // See the docs on `arch`: https://github.com/cmake-js/cmake-js/blob/v6.1.0/README.md?#runtimes
+    // > Notice: on non-Windows systems the C++ toolset's architecture's gonna be used despite this setting.
     if (platform === 'darwin') {
-        // Node calls it "x64" but Apple calls it "x86_64", they both agree on "arm64" though
+        // What Node calls "x64", Apple calls "x86_64". They both agree on the term "arm64" though.
         options.cMakeOptions.CMAKE_OSX_ARCHITECTURES = (arch === 'x64') ? 'x86_64' : arch;
     }
 

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -99,32 +99,46 @@ async function fetchNativeCode(url, version, path) {
 }
 
 function buildLocally() {
+    let arch = os.arch;
+
+    // Allow cross-compile (allow OSX to do arm64 or x64 builds)
+    if (process.argv.includes('--force-arch')) {
+        arch = process.argv[process.argv.indexOf('--force-arch') + 1];
+    }
+
     let options = {
-        CMAKE_EXPORT_COMPILE_COMMANDS: true,
-        CMAKE_JS_PLATFORM: os.platform,
-        CMAKE_JS_ARCH: os.arch,
-        BUILD_TESTING: 'OFF',
-        CMAKE_INSTALL_PREFIX: 'crt/install',
-        CMAKE_PREFIX_PATH: 'crt/install',
+        target: "install",
+        debug: process.argv.includes('--debug'),
+        arch: arch,
+        out: path.join('build', `${os.platform}-${arch}`),
+        cMakeOptions: {
+            CMAKE_EXPORT_COMPILE_COMMANDS: true,
+            CMAKE_JS_PLATFORM: os.platform,
+            BUILD_TESTING: 'OFF',
+            CMAKE_INSTALL_PREFIX: 'crt/install',
+            CMAKE_PREFIX_PATH: 'crt/install',
+        }
     }
 
     // Convert any -D arguments to this script to cmake -D arguments
     for (const arg of process.argv) {
         if (arg.startsWith('-D')) {
             const option = arg.substring(2).split('=')
-            options[option[0]] = option[1]
+            options.cMakeOptions[option[0]] = option[1]
         }
     }
 
     // Enable parallel build (ignored by cmake older than 3.12)
     process.env.CMAKE_BUILD_PARALLEL_LEVEL = `${Math.max(os.cpus().length, 1)}`;
 
+    // Allow cross-compile on OSX
+    if (os.platform == 'darwin') {
+        let osx_arch = (arch == 'x64') ? 'x86_64' : arch;
+        options.cMakeOptions.CMAKE_OSX_ARCHITECTURES = osx_arch;
+    }
+
     // Run the build
-    var buildSystem = new cmake.BuildSystem({
-        target: "install",
-        debug: process.argv.includes('--debug'),
-        cMakeOptions: options,
-    });
+    var buildSystem = new cmake.BuildSystem(options);
     return buildSystem.build();
 }
 

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -7,7 +7,7 @@ const process = require("process");
 const path = require("path");
 const fs = require("fs");
 
-const binaryDir = path.join('dist', 'bin', `${os.platform}-${os.arch}`, 'aws-crt-nodejs.node');
+const binaryDir = path.join('dist', 'bin', `${os.platform()}-${os.arch()}`, 'aws-crt-nodejs.node');
 if (fs.existsSync(binaryDir)) {
     // Don't continue if the binding already exists (unless --rebuild is specified)
     process.exit(0);

--- a/source/io.c
+++ b/source/io.c
@@ -913,8 +913,8 @@ static int s_input_stream_read(struct aws_input_stream *stream, struct aws_byte_
 
     aws_mutex_lock(&impl->mutex);
     if (!aws_byte_buf_write(dest, impl->buffer.buffer, bytes_to_read)) {
-        return AWS_OP_ERR;
         aws_mutex_unlock(&impl->mutex);
+        return AWS_OP_ERR;
     }
     aws_mutex_unlock(&impl->mutex);
 


### PR DESCRIPTION
**Issue:**
NPM package lacked arm64 binaries for macOS, so it didn't work as nicely on newer M1 Macs.

**Description of Changes:**
NPM package now includes arm64 binaries for macOS.

* Support cross-compiling on macOS, so any machine can make an x64 or arm64 binary.
  * Can't just use an arm64 machine because we only have access to x64 macOS in our release pipeline.
  * Decided against creating a single "universal" binary. It's a hassle to build (need to compile for both x64, then arm64, then glue them together with lipo) and would increase iteration time when developing on a Mac. And since our code [picks which binary to load](https://github.com/awslabs/aws-crt-nodejs/blob/12d30161dd8a3f78c0428caafe6ba1bd12b43288/lib/native/binding.js#L22), having distinct binaries seems simpler for now.
* A single `build-osx-x64-arm64.sh` job builds both x64 and arm64 binaries.
  * Decided against a separate arm64 job since we only have an x64 machine right now. So `npm install` isn't going to naturally spit out an arm64 build. Therefore we must cross-compile. And it seemed simplest to do that after the normal `npm install` that pulls dependencies but also creates the x64 binary.
* No more support for binaries in the `dist/bin/native/` folder 
  * This was leading to weird errors. The platform must be known at build time now.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
