### PR TITLE
MQTT builder custom authorizer support

### DIFF
--- a/lib/browser/mqtt.ts
+++ b/lib/browser/mqtt.ts
@@ -237,7 +237,6 @@ export class MqttClientConnection extends BufferedEventEmitter {
         } : undefined;
 
         const websocketXform = (config.websocket || {}).protocol != 'wss-custom-auth' ? transform_websocket_url : undefined;
-
         this.connection = new mqtt.MqttClient(
             create_websocket_stream,
             {

--- a/lib/common/aws_iot_shared.ts
+++ b/lib/common/aws_iot_shared.ts
@@ -36,7 +36,7 @@
  * A helper function to see if a string is not null, is defined, and is not an empty string
  */
  export function is_string_and_not_empty(item : any) {
-    return item != undefined && item != null && item != "";
+    return item != undefined && typeof(item) == 'string' && item != "";
 }
 
 /**

--- a/lib/common/aws_iot_shared.ts
+++ b/lib/common/aws_iot_shared.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+/**
+ *
+ * A module containing miscellaneous functionality that is shared across both native and browser for aws_iot
+ *
+ * @packageDocumentation
+ * @module aws_iot
+ * @preferred
+ */
+
+
+/**
+ * A helper function to add parameters to the username in with_custom_authorizer function
+ */
+ export function add_to_username_parameter(current_username : string, parameter_value : string, parameter_pre_text : string) {
+    let return_string = current_username;
+
+    if (return_string.indexOf("?") != -1) {
+        return_string += "&"
+    } else {
+        return_string += "?"
+    }
+
+    if (parameter_value.indexOf(parameter_pre_text) != -1) {
+        return return_string + parameter_value;
+    } else {
+        return return_string + parameter_pre_text + parameter_value;
+    }
+}
+
+/**
+ * A helper function to see if a string is not null, is defined, and is not an empty string
+ */
+ export function is_string_and_not_empty(item : any) {
+    return item != undefined && item != null && item != "";
+}
+
+/**
+ * A helper function to populate the username with the Custom Authorizer fields
+ * @param current_username the current username
+ * @param input_username the username to add - can be an empty string to skip
+ * @param input_authorizer the name of the authorizer to add - can be an empty string to skip
+ * @param input_signature the name of the signature to add - can be an empty string to skip
+ * @param input_builder_username the username from the MQTT builder
+ * @returns The finished username with the additions added to it
+ */
+export function populate_username_string_with_custom_authorizer(
+    current_username? : string, input_username? : string, input_authorizer? : string,
+    input_signature? : string, input_builder_username? : string) {
+
+    let username_string = "";
+
+    if (current_username) {
+        username_string += current_username;
+    }
+    if (is_string_and_not_empty(input_username) == false) {
+        if (is_string_and_not_empty(input_builder_username) && input_builder_username) {
+            username_string += input_builder_username;
+        }
+    }
+    else {
+        username_string += input_username;
+    }
+
+    if (is_string_and_not_empty(input_authorizer) && input_authorizer) {
+        username_string = add_to_username_parameter(username_string, input_authorizer, "x-amz-customauthorizer-name=");
+    }
+    if (is_string_and_not_empty(input_signature) && input_signature) {
+        username_string = add_to_username_parameter(username_string, input_signature, "x-amz-customauthorizer-signature=");
+    }
+
+    return username_string;
+}
+

--- a/lib/native/aws_iot.ts
+++ b/lib/native/aws_iot.ts
@@ -410,8 +410,8 @@ export class AwsIotMqttConnectionConfigBuilder {
 
         // Check to see if a custom authorizer is being used but not through the builder
         if (this.is_using_custom_authorizer == false) {
-            if (iot_shared.is_string_and_not_empty(this.params.username) && this.params.username) {
-                if (this.params.username.indexOf("x-amz-customauthorizer-name=") != -1 || this.params.username.indexOf("x-amz-customauthorizer-signature=") != -1) {
+            if (iot_shared.is_string_and_not_empty(this.params.username)) {
+                if (this.params.username?.indexOf("x-amz-customauthorizer-name=") != -1 || this.params.username?.indexOf("x-amz-customauthorizer-signature=") != -1) {
                     this.is_using_custom_authorizer = true;
                 }
             }
@@ -441,12 +441,10 @@ export class AwsIotMqttConnectionConfigBuilder {
         if (iot_shared.is_string_and_not_empty(this.params.username) == false) {
             this.params.username = "?SDK=NodeJSv2&Version="
         } else {
-            if (this.params.username) { // needed to fix possibly undefined error
-                if (this.params.username.indexOf("?") != -1) {
-                    this.params.username += "&SDK=NodeJSv2&Version="
-                } else {
-                    this.params.username += "?SDK=NodeJSv2&Version="
-                }
+            if (this.params.username?.indexOf("?") != -1) {
+                this.params.username += "&SDK=NodeJSv2&Version="
+            } else {
+                this.params.username += "?SDK=NodeJSv2&Version="
             }
         }
         this.params.username += platform.crt_version()

--- a/lib/native/aws_iot.ts
+++ b/lib/native/aws_iot.ts
@@ -390,7 +390,7 @@ export class AwsIotMqttConnectionConfigBuilder {
         let username_string = "";
         let added_string_to_username = false;
 
-        if (username == "" || username == null || username == undefined) {
+        if (username == "" || username == null) {
             if (this.params.username != "" && this.params.username != null && this.params.username != undefined) {
                 username_string += this.params.username;
             }
@@ -399,11 +399,11 @@ export class AwsIotMqttConnectionConfigBuilder {
             username_string += username;
         }
 
-        if (authorizer_name != "" && authorizer_name != null && authorizer_name != undefined) {
+        if (authorizer_name != "" && authorizer_name != null) {
             username_string = this.add_username_parameter(username_string, authorizer_name, "x-amz-customauthorizer-name=", added_string_to_username);
             added_string_to_username = true;
         }
-        if (authorizer_signature != "" && authorizer_signature != null && authorizer_signature != undefined) {
+        if (authorizer_signature != "" && authorizer_signature != null) {
             username_string = this.add_username_parameter(username_string, authorizer_signature, "x-amz-customauthorizer-signature=", added_string_to_username);
         }
 

--- a/lib/native/aws_iot.ts
+++ b/lib/native/aws_iot.ts
@@ -79,7 +79,6 @@ export class AwsIotMqttConnectionConfigBuilder {
             clean_session: false,
             keep_alive: undefined,
             will: undefined,
-            //username: `?SDK=NodeJSv2&Version=${platform.crt_version()}`,
             username: "",
             password: undefined,
             tls_ctx: undefined,
@@ -456,7 +455,7 @@ export class AwsIotMqttConnectionConfigBuilder {
         // Is the user trying to connect using a custom authorizer?
         if (this.is_using_custom_authorizer == true) {
             if (this.params.port != 443) {
-                // TODO - ideally print a warning here
+                console.log("Warning: Attempting to connect to authorizer with unsupported port. Port is not 443...");
             }
             if (this.tls_ctx_options.alpn_list != ["mqtt"]) {
                 this.tls_ctx_options.alpn_list = ["mqtt"]


### PR DESCRIPTION
*Description of changes:*

Modified MQTT connection builder to allow custom authorizer support. Added missing username and password options, and also added a function to make a default builder. All of these changes make MQTT connection builder closer to the Java V2 SDK in option parity, as well as adding custom authorizer support.

__________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
