### PR TITLE
Typescript upgrade

### DIFF
--- a/docsrc/typedoc-browser.json
+++ b/docsrc/typedoc-browser.json
@@ -1,14 +1,32 @@
 {
-    "mode": "modules",
-    "inputFiles": "lib/browser.ts",
-    "tsconfig": "tsconfig.browser.json",
-    "out": "docs/browser",
-    "includeDeclarations": true,
+    "entryPoints": [
+        "../lib/browser/auth.ts",
+        "../lib/browser/aws_iot.ts",
+        "../lib/browser/crypto.ts",
+        "../lib/browser/error.ts",
+        "../lib/browser/http.ts",
+        "../lib/browser/io.ts",
+        "../lib/browser/mqtt.ts",
+        "../lib/browser/ws.ts",
+        "../lib/common/auth.ts",
+        "../lib/common/crypto.ts",
+        "../lib/common/event.ts",
+        "../lib/common/http.ts",
+        "../lib/common/io.ts",
+        "../lib/common/mqtt.ts"
+    ],
+    "tsconfig": "../tsconfig.browser.json",
+    "out": "../docs/browser",
     "excludeExternals": true,
-    "excludeNotExported": true,
     "excludePrivate": true,
-    "stripInternal": true,
+    "excludeInternal": true,
+    "excludeProtected": true,
     "disableSources": true,
-    "listInvalidSymbolLinks": true
+    "categorizeByGroup": true,
+    "validation": {
+        "invalidLink" : true
+    },
+    "treatWarningsAsErrors" : true,
+    "mergeModulesMergeMode": "module"
 }
 

--- a/docsrc/typedoc-node.json
+++ b/docsrc/typedoc-node.json
@@ -1,15 +1,33 @@
 {
-    "mode": "modules",
-    "inputFiles": ["lib/index.ts", "lib/native/*.ts", "lib/common/*.ts"],
-    "exclude": ["lib/native/binding.js", "lib/browser", "lib/native/*.spec.ts", "lib/common/*.spec.ts"],
-    "out": "docs/node",
-    "includeDeclarations": true,
+    "entryPoints": [
+        "../lib/native/auth.ts",
+        "../lib/native/aws_iot.ts",
+        "../lib/native/checksums.ts",
+        "../lib/native/crt.ts",
+        "../lib/native/crypto.ts",
+        "../lib/native/error.ts",
+        "../lib/native/http.ts",
+        "../lib/native/io.ts",
+        "../lib/native/mqtt.ts",
+        "../lib/native/binding.d.ts",
+        "../lib/common/auth.ts",
+        "../lib/common/crypto.ts",
+        "../lib/common/event.ts",
+        "../lib/common/http.ts",
+        "../lib/common/mqtt.ts",
+        "../lib/common/resource_safety.ts"
+    ],
+    "out": "../docs/node",
     "excludeExternals": true,
-    "excludeNotExported": true,
     "excludePrivate": true,
-    "stripInternal": true,
+    "excludeInternal": true,
+    "excludeProtected": true,
     "disableSources": true,
     "categorizeByGroup": true,
-    "listInvalidSymbolLinks": true
+    "validation": {
+        "invalidLink" : true
+    },
+    "treatWarningsAsErrors" : true,
+    "mergeModulesMergeMode": "module"
 }
 

--- a/lib/browser.ts
+++ b/lib/browser.ts
@@ -3,11 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-/**
- * @packageDocumentation
- * @module crt
- */
-
 // This is the entry point for the browser AWS CRT shim library
 
 /* common libs */

--- a/lib/browser/auth.ts
+++ b/lib/browser/auth.ts
@@ -8,7 +8,7 @@
  *
  * @packageDocumentation
  * @module auth
- * @preferred
+ * @mergeTarget
  */
 
 import { AwsSigningConfigBase } from '../common/auth';

--- a/lib/browser/aws_iot.ts
+++ b/lib/browser/aws_iot.ts
@@ -7,8 +7,8 @@
  * Module for AWS IoT configuration and connection establishment
  *
  * @packageDocumentation
- * @module aws-iot
- * @preferred
+ * @module aws_iot
+ * @mergeTarget
  */
 
 import { CredentialsProvider, StaticCredentialProvider} from "./auth"

--- a/lib/browser/crypto.ts
+++ b/lib/browser/crypto.ts
@@ -4,9 +4,11 @@
  */
 
 /**
+ * A module containing support for a variety of cryptographic operations.
  *
  * @packageDocumentation
  * @module crypto
+ * @mergeTarget
  */
 
 import * as Crypto from "crypto-js";

--- a/lib/browser/error.ts
+++ b/lib/browser/error.ts
@@ -4,8 +4,11 @@
  */
 
 /**
+ * Library-specific error extension type
+ *
  * @packageDocumentation
- * @module crt
+ * @module error
+ * @mergeTarget
  */
 
 /**

--- a/lib/browser/http.ts
+++ b/lib/browser/http.ts
@@ -4,8 +4,12 @@
  */
 
 /**
+ *
+ * A module containing support for creating http connections and making requests on them.
+ *
  * @packageDocumentation
  * @module http
+ * @mergeTarget
  */
 
 import {
@@ -267,31 +271,28 @@ export class HttpClientConnection extends BufferedEventEmitter {
     /**
      * Emitted when the connection is connected and ready to start streams
      *
-     * @param event type of event (connect)
-     * @param listener event listener to use
-     *
      * @event
      */
-    on(event: 'connect', listener: HttpClientConnectionConnected): this;
+    static CONNECT = 'connect';
 
     /**
      * Emitted when an error occurs on the connection
      *
-     * @param event type of event (error)
-     * @param listener event listener to use
-     *
      * @event
      */
-    on(event: 'error', listener: HttpClientConnectionError): this;
+    static ERROR = 'error';
 
     /**
      * Emitted when the connection has completed
      *
-     * @param event type of event (close)
-     * @param listener event listener to use
-     *
      * @event
      */
+    static CLOSE = 'close';
+
+    on(event: 'connect', listener: HttpClientConnectionConnected): this;
+
+    on(event: 'error', listener: HttpClientConnectionError): this;
+
     on(event: 'close', listener: HttpClientConnectionClosed): this;
 
     // Override to allow uncorking on ready
@@ -402,42 +403,37 @@ export class HttpClientStream extends BufferedEventEmitter {
     /**
      * Emitted when the http response headers have arrived.
      *
-     * @param event type of event (response)
-     * @param listener event listener to use
-     *
      * @event
      */
-    on(event: 'response', listener: HttpStreamResponse): this;
-
+    static RESPONSE = 'response';
 
     /**
      * Emitted when http response data is available.
      *
-     * @param event type of event (data)
-     * @param listener event listener to use
-     *
      * @event
      */
-    on(event: 'data', listener: HttpStreamData): this;
+    static DATA = 'data';
 
     /**
      * Emitted when an error occurs in stream processing
      *
-     * @param event type of event (error)
-     * @param listener event listener to use
-     *
      * @event
      */
-    on(event: 'error', listener: HttpStreamError): this;
+    static ERROR = 'error';
 
     /**
      * Emitted when the stream has completed
      *
-     * @param event type of event (end)
-     * @param listener event listener to use
-     *
      * @event
      */
+    static END = 'end';
+
+    on(event: 'response', listener: HttpStreamResponse): this;
+
+    on(event: 'data', listener: HttpStreamData): this;
+
+    on(event: 'error', listener: HttpStreamError): this;
+
     on(event: 'end', listener: HttpStreamComplete): this;
 
     on(event: string | symbol, listener: (...args: any[]) => void): this {

--- a/lib/browser/http.ts
+++ b/lib/browser/http.ts
@@ -359,7 +359,6 @@ function stream_request(connection: HttpClientConnection, request: HttpRequest) 
  * @param status_code http response status code
  * @param headers the response's set of headers
  *
- * @asMemberOf HttpClientStream
  * @category HTTP
  */
 export type HttpStreamResponse = (status_code: number, headers: HttpHeaders) => void;

--- a/lib/browser/io.ts
+++ b/lib/browser/io.ts
@@ -5,8 +5,18 @@
 
 /**
  *
+ * A module containing a grab bag of support for core network I/O functionality, including sockets, TLS, DNS, logging,
+ * error handling, streams, and connection -> thread mapping.
+ *
+ * Categories include:
+ * - Network: socket configuration
+ * - TLS: tls configuration
+ * - Logging: logging controls and configuration
+ * - IO: everything else
+ *
  * @packageDocumentation
- * @module IO
+ * @module io
+ * @mergeTarget
  */
 
 export { TlsVersion, SocketType, SocketDomain } from "../common/io";
@@ -21,7 +31,7 @@ export function is_alpn_available(): boolean {
     return false;
 }
 
-type BodyData = string | object | ArrayBuffer | ArrayBufferView | Blob | File;
+export type BodyData = string | object | ArrayBuffer | ArrayBufferView | Blob | File;
 
 /**
  * Wrapper for any sort of body data in requests. As the browser does not implement streaming,

--- a/lib/browser/mqtt.ts
+++ b/lib/browser/mqtt.ts
@@ -40,7 +40,6 @@ export { QoS, Payload, MqttRequest, MqttSubscribeRequest, MqttWill } from "../co
  *
  * @param error the error that occurred
  *
- * @asMemberOf MqttClientConnection
  * @category MQTT
  */
 export type MqttConnectionError = (error: CrtError) => void;
@@ -51,7 +50,6 @@ export type MqttConnectionError = (error: CrtError) => void;
  *
  * @param error description of the error that occurred
  *
- * @asMemberOf MqttClientConnection
  * @category MQTT
  */
 export type MqttConnectionInterrupted = (error: CrtError) => void;

--- a/lib/browser/ws.ts
+++ b/lib/browser/ws.ts
@@ -4,8 +4,11 @@
  */
 
 /**
+ * Module for utilities related to websocket connection establishment
+ *
  * @packageDocumentation
- * @module mqtt
+ * @module ws
+ * @mergeTarget
  */
 
 import { MqttConnectionConfig } from "./mqtt";
@@ -19,27 +22,31 @@ import * as Crypto from "crypto-js";
  *
  * @category MQTT
  */
-export interface WebsocketOptions extends WebsocketOptionsBase{
+export interface WebsocketOptions extends WebsocketOptionsBase {
     /** Additional headers to add */
     headers?: { [index: string]: string };
     /** Websocket protocol, used during Upgrade */
     protocol?: string;
 }
 
+/** @internal */
 function zero_pad(n: number) {
     return (n > 9) ? n : '0' + n.toString();
 }
 
+/** @internal */
 function canonical_time(time?: Date) {
     const now = time?? new Date();
     return `${now.getUTCFullYear()}${zero_pad(now.getUTCMonth() + 1)}${zero_pad(now.getUTCDate())}T` +
         `${zero_pad(now.getUTCHours())}${zero_pad(now.getUTCMinutes())}${zero_pad(now.getUTCSeconds())}Z`;
 }
 
+/** @internal */
 function canonical_day(time: string = canonical_time()) {
     return time.substring(0, time.indexOf('T'));
 }
 
+/** @internal */
 function make_signing_key(credentials: AWSCredentials, day: string, service_name: string) {
     const hash_opts = { asBytes: true };
     let hash = Crypto.HmacSHA256(day, 'AWS4' + credentials.aws_secret_key, hash_opts);
@@ -49,6 +56,7 @@ function make_signing_key(credentials: AWSCredentials, day: string, service_name
     return hash;
 }
 
+/** @internal */
 function sign_url(method: string,
     url: URL,
     signing_config: AwsSigningConfig,

--- a/lib/common/auth.ts
+++ b/lib/common/auth.ts
@@ -4,8 +4,6 @@
  */
 
 /**
- * TestCommon
- *
  * @packageDocumentation
  * @module auth
  */

--- a/lib/common/auth.ts
+++ b/lib/common/auth.ts
@@ -4,11 +4,17 @@
  */
 
 /**
+ * TestCommon
+ *
+ * @packageDocumentation
+ * @module auth
+ */
+
+/**
  * Configuration for use in AWS-related signing.
  * AwsSigningConfig is immutable.
  * It is good practice to use a new config for each signature, or the date might get too old.
  *
- * @internal
  */
 export interface AwsSigningConfigBase {
 
@@ -28,7 +34,6 @@ export interface AwsSigningConfigBase {
  * Configuration for websocket signing
  * It is good practice to use a new config for each signature, or the date might get too old.
  *
- * @Internal
  */
 export interface WebsocketOptionsBase {
     /**

--- a/lib/common/aws_iot_shared.ts
+++ b/lib/common/aws_iot_shared.ts
@@ -9,12 +9,13 @@
  *
  * @packageDocumentation
  * @module aws_iot
- * @preferred
  */
 
 
 /**
  * A helper function to add parameters to the username in with_custom_authorizer function
+ *
+ * @internal
  */
  export function add_to_username_parameter(current_username : string, parameter_value : string, parameter_pre_text : string) {
     let return_string = current_username;
@@ -34,6 +35,8 @@
 
 /**
  * A helper function to see if a string is not null, is defined, and is not an empty string
+ *
+ * @internal
  */
  export function is_string_and_not_empty(item : any) {
     return item != undefined && typeof(item) == 'string' && item != "";
@@ -47,6 +50,8 @@
  * @param input_signature the name of the signature to add - can be an empty string to skip
  * @param input_builder_username the username from the MQTT builder
  * @returns The finished username with the additions added to it
+ *
+ * @internal
  */
 export function populate_username_string_with_custom_authorizer(
     current_username? : string, input_username? : string, input_authorizer? : string,

--- a/lib/common/crypto.ts
+++ b/lib/common/crypto.ts
@@ -9,7 +9,6 @@
  *
  * @packageDocumentation
  * @module crypto
- * @preferred
  */
 
 /**

--- a/lib/common/event.ts
+++ b/lib/common/event.ts
@@ -4,8 +4,10 @@
  */
 
 /**
+ * Module for base types related to event emission
+ *
  * @packageDocumentation
- * @module crt
+ * @module events
  */
 
 import { EventEmitter } from 'events';
@@ -15,7 +17,7 @@ import { EventEmitter } from 'events';
  *
  * @category Events
  */
-type EventKey = string | symbol;
+export type EventKey = string | symbol;
 
 /**
  * @internal
@@ -30,9 +32,9 @@ class BufferedEvent {
 
 /**
  * Provides buffered event emitting semantics, similar to many Node-style streams.
- * Subclasses will override {@link BufferedEventEmitter.on} and trigger uncorking.
+ * Subclasses will override EventEmitter.on() and trigger uncorking.
  * NOTE: It is HIGHLY recommended that uncorking should always be done via
- * ```process.nextTick()```, not during the {@link BufferedEventEmitter.on} call.
+ * ```process.nextTick()```, not during the EventEmitter.on() call.
  *
  * See also: [Node writable streams](https://nodejs.org/api/stream.html#stream_writable_cork)
  *

--- a/lib/common/event.ts
+++ b/lib/common/event.ts
@@ -7,7 +7,7 @@
  * Module for base types related to event emission
  *
  * @packageDocumentation
- * @module events
+ * @module event
  */
 
 import { EventEmitter } from 'events';

--- a/lib/common/http.ts
+++ b/lib/common/http.ts
@@ -10,7 +10,6 @@
  *
  * @packageDocumentation
  * @module http
- * @preferred
  */
 
 /**
@@ -35,7 +34,11 @@ export enum HttpVersion {
  */
 export type HttpHeader = [string, string];
 
-/** @internal */
+/**
+ * Common interface for a set of HTTP headers.
+ *
+ * @category HTTP
+ */
 export interface HttpHeaders {
     readonly length: number;
 

--- a/lib/common/http.ts
+++ b/lib/common/http.ts
@@ -146,7 +146,6 @@ export class CommonHttpProxyOptions {
  * Listener signature for event emitted from an {@link HttpClientConnection} when the connection reaches the
  * connected state
  *
- * @asMemberOf HttpClientConnection
  * @category HTTP
  */
 export type HttpClientConnectionConnected = () => void;
@@ -156,7 +155,6 @@ export type HttpClientConnectionConnected = () => void;
  *
  * @param error - A CrtError containing the error that occurred
  *
- * @asMemberOf HttpClientConnection
  * @category HTTP
  */
 export type HttpClientConnectionError = (error: Error) => void;
@@ -164,7 +162,6 @@ export type HttpClientConnectionError = (error: Error) => void;
 /**
  * Listener signature for event emitted from an {@link HttpClientConnection} when the connection has been closed
  *
- * @asMemberOf HttpClientConnection
  * @category HTTP
  */
 export type HttpClientConnectionClosed = () => void;
@@ -174,7 +171,6 @@ export type HttpClientConnectionClosed = () => void;
  *
  * @param body_data - The chunk of body data
  *
- * @asMemberOf HttpClientStream
  * @category HTTP
  */
 export type HttpStreamData = (body_data: ArrayBuffer) => void;
@@ -185,7 +181,6 @@ export type HttpStreamData = (body_data: ArrayBuffer) => void;
  *
  * @param error - A CrtError containing the error that occurred
  *
- * @asMemberOf HttpClientStream
  * @category HTTP
  */
 export type HttpStreamError = (error: Error) => void;
@@ -193,7 +188,6 @@ export type HttpStreamError = (error: Error) => void;
 /**
  * Listener signature for event emitted from an {@link HttpClientStream} when the http stream has completed.
  *
- * @asMemberOf HttpClientStream
  * @category HTTP
  */
 export type HttpStreamComplete = () => void;

--- a/lib/common/io.ts
+++ b/lib/common/io.ts
@@ -15,8 +15,7 @@
  * - IO: everything else
  *
  * @packageDocumentation
- * @module IO
- * @preferred
+ * @module io
  */
 
 /**

--- a/lib/common/mqtt.ts
+++ b/lib/common/mqtt.ts
@@ -9,16 +9,7 @@
  *
  * @packageDocumentation
  * @module mqtt
- * @preferred
  */
-
-/**
- * MQTT Quality of Service
- * [MQTT-4.3]
- *
- * @category MQTT
- */
-import {CrtError} from "../browser/error";
 
 /**
  * Quality of service control for mqtt publish operations
@@ -147,27 +138,6 @@ export type MqttConnectionConnected = (session_present: boolean) => void;
  * @category MQTT
  */
 export type MqttConnectionDisconnected = () => void;
-
-/**
- * Listener signature for event emitted from an {@link MqttClientConnection} when an error occurs
- *
- * @param error the error that occurred
- *
- * @asMemberOf MqttClientConnection
- * @category MQTT
- */
-export type MqttConnectionError = (error: CrtError) => void;
-
-/**
- * Listener signature for event emitted from an {@link MqttClientConnection} when the connection has been
- * interrupted unexpectedly.
- *
- * @param error description of the error that occurred
- *
- * @asMemberOf MqttClientConnection
- * @category MQTT
- */
-export type MqttConnectionInterrupted = (error: CrtError) => void;
 
 /**
  * Listener signature for event emitted from an {@link MqttClientConnection} when the connection successfully

--- a/lib/common/mqtt.ts
+++ b/lib/common/mqtt.ts
@@ -125,7 +125,6 @@ export class MqttWill {
  *
  * @param session_present true if the reconnection went to an existing session, false if this is a clean session
  *
- * @asMemberOf MqttClientConnection
  * @category MQTT
  */
 export type MqttConnectionConnected = (session_present: boolean) => void;
@@ -134,7 +133,6 @@ export type MqttConnectionConnected = (session_present: boolean) => void;
  * Listener signature for event emitted from an {@link MqttClientConnection} when the connection has fully disconnected
  * by user request
  *
- * @asMemberOf MqttClientConnection
  * @category MQTT
  */
 export type MqttConnectionDisconnected = () => void;
@@ -146,7 +144,6 @@ export type MqttConnectionDisconnected = () => void;
  * @param return_code MQTT connect return code (should be 0 for a successful reconnection)
  * @param session_present true if the reconnection went to an existing session, false if this is a clean session
  *
- * @asMemberOf MqttClientConnection
  * @category MQTT
  */
 export type MqttConnectionResumed = (return_code: number, session_present: boolean) => void;

--- a/lib/common/platform.ts
+++ b/lib/common/platform.ts
@@ -5,11 +5,11 @@
 
 /**
  *
- * A module containing miscellaneous functionality for error reporting, platform functionality, and package-wide logic.
+ * A module containing miscellaneous platform-related queries
  *
  * @packageDocumentation
- * @module crt
- * @preferred
+ * @module platform
+ * @mergeTarget
  */
 
 /**

--- a/lib/common/resource_safety.ts
+++ b/lib/common/resource_safety.ts
@@ -4,8 +4,12 @@
  */
 
 /**
+ *
+ * A module containing miscellaneous types for resource management
+ *
  * @packageDocumentation
- * @module crt
+ * @module resource_safety
+ * @mergeTarget
  */
 
 /**

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -3,11 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-/**
- * @packageDocumentation
- * @module crt
- */
-
 // This is the entry point for the AWS CRT nodejs native libraries
 
 /* common libs */
@@ -22,6 +17,7 @@ import * as http from './native/http';
 import * as crypto from './native/crypto';
 import * as auth from './native/auth';
 import * as iot from './native/aws_iot';
+import * as checksums from './native/checksums';
 import { CrtError } from './native/error';
 
 export {
@@ -34,5 +30,6 @@ export {
     iot,
     platform,
     resource_safety,
+    checksums,
     CrtError
 };

--- a/lib/native/auth.ts
+++ b/lib/native/auth.ts
@@ -8,7 +8,7 @@
  *
  * @packageDocumentation
  * @module auth
- * @preferred
+ * @mergeTarget
  */
 
 import * as auth from '../common/auth';

--- a/lib/native/aws_iot.ts
+++ b/lib/native/aws_iot.ts
@@ -18,6 +18,7 @@ import { TlsContextOptions } from "./io";
 import * as platform from '../common/platform';
 import { HttpProxyOptions } from "./http";
 import { WebsocketOptionsBase } from "../common/auth";
+import { CrtError } from "./error";
 
 import {
     aws_sign_request,
@@ -178,7 +179,11 @@ export class AwsIotMqttConnectionConfigBuilder {
                     await aws_sign_request(request, signing_config as AwsSigningConfig);
                     done();
                 } catch (error) {
-                    done(error);
+                    if (error instanceof CrtError) {
+                        done(error.error_code);
+                    } else {
+                        done(3); /* TODO: AWS_ERROR_UNKNOWN */
+                    }
                 }
             };
         }

--- a/lib/native/aws_iot.ts
+++ b/lib/native/aws_iot.ts
@@ -7,8 +7,8 @@
  * Module for AWS IoT configuration and connection establishment
  *
  * @packageDocumentation
- * @module aws-iot
- * @preferred
+ * @module aws_iot
+ * @mergeTarget
  */
 
 import { MqttConnectionConfig, MqttWill} from "./mqtt";

--- a/lib/native/binding.d.ts
+++ b/lib/native/binding.d.ts
@@ -22,7 +22,6 @@ import { OnMessageCallback, QoS } from "../common/mqtt";
  */
 type NativeHandle = any;
 
-/** @internal */
 type StringLike = string | ArrayBuffer | ArrayBufferView;
 
 /* common */
@@ -375,7 +374,6 @@ export class HttpRequest {
     public body: InputStream;
 }
 
-/** @internal */
 export class AwsCredentialsProvider {
     protected constructor();
 

--- a/lib/native/binding.js
+++ b/lib/native/binding.js
@@ -10,6 +10,7 @@ import { versions } from 'process';
 
 const upgrade_string = "Please upgrade to node >=10.16.0, or use the provided browser implementation.";
 if ('napi' in versions) {
+    // @ts-ignore
     const napi_version = parseInt(versions['napi']);
     if (napi_version < 4) {
         throw new Error("The AWS CRT native implementation requires that NAPI version 4 be present. " + upgrade_string);

--- a/lib/native/checksums.ts
+++ b/lib/native/checksums.ts
@@ -4,8 +4,12 @@
  */
 
 /**
+ *
+ * A module containing various checksum implementations intended for streaming payloads
+ *
  * @packageDocumentation
- * @module crypto
+ * @module checksums
+ * @mergeTarget
  */
 
  import crt_native from './binding';

--- a/lib/native/crt.ts
+++ b/lib/native/crt.ts
@@ -4,8 +4,12 @@
  */
 
 /**
+ *
+ * A module containing some miscellaneous crt native memory queries
+ *
  * @packageDocumentation
  * @module crt
+ * @mergeTarget
  */
 
 /**

--- a/lib/native/crypto.ts
+++ b/lib/native/crypto.ts
@@ -4,8 +4,11 @@
  */
 
 /**
+ * A module containing support for a variety of cryptographic operations.
+ *
  * @packageDocumentation
  * @module crypto
+ * @mergeTarget
  */
 
 import crt_native from './binding';

--- a/lib/native/error.ts
+++ b/lib/native/error.ts
@@ -4,12 +4,14 @@
  */
 
 /**
+ * Library-specific error extension type
+ *
  * @packageDocumentation
- * @module crt
+ * @module error
+ * @mergeTarget
  */
 
 import crt_native from './binding';
-import { isNumber } from 'util';
 
 /**
  * Represents an error encountered in native code. Can also be used to convert a numeric error code into
@@ -32,7 +34,7 @@ export class CrtError extends Error {
 }
 
 function extract_message(error: any): string {
-    if (isNumber(error)) {
+    if (typeof error === 'number') {
         return crt_native.error_code_to_string(error);
     } else if (error instanceof CrtError) {
         return error.message;
@@ -41,7 +43,7 @@ function extract_message(error: any): string {
 }
 
 function extract_code(error: any) {
-    if (isNumber(error)) {
+    if (typeof error === 'number') {
         return error;
     } else if (error instanceof CrtError) {
         return error.error_code;
@@ -50,7 +52,7 @@ function extract_code(error: any) {
 }
 
 function extract_name(error: any) {
-    if (isNumber(error)) {
+    if (typeof error === 'number') {
         return crt_native.error_code_to_name(error);
     } else if (error instanceof CrtError) {
         return error.error_name;

--- a/lib/native/http.ts
+++ b/lib/native/http.ts
@@ -4,8 +4,12 @@
  */
 
 /**
+ *
+ * A module containing support for creating http connections and making requests on them.
+ *
  * @packageDocumentation
  * @module http
+ * @mergeTarget
  */
 
 import crt_native from './binding';
@@ -80,31 +84,28 @@ export class HttpConnection extends NativeResourceMixin(BufferedEventEmitter) im
     /**
      * Emitted when the connection is connected and ready to start streams
      *
-     * @param event type of event (connect)
-     * @param listener event listener to use
-     *
      * @event
      */
-    on(event: 'connect', listener: HttpClientConnectionConnected): this;
+    static CONNECT = 'connect';
 
     /**
      * Emitted when an error occurs on the connection
      *
-     * @param event type of event (error)
-     * @param listener event listener to use
-     *
      * @event
      */
-    on(event: 'error', listener: HttpClientConnectionError): this;
+    static ERROR = 'error';
 
     /**
      * Emitted when the connection has completed
      *
-     * @param event type of event (close)
-     * @param listener event listener to use
-     *
      * @event
      */
+    static CLOSE = 'close';
+
+    on(event: 'connect', listener: HttpClientConnectionConnected): this;
+
+    on(event: 'error', listener: HttpClientConnectionError): this;
+
     on(event: 'close', listener: HttpClientConnectionClosed): this;
 
     // Overridden to allow uncorking on ready
@@ -394,52 +395,46 @@ export class HttpClientStream extends HttpStream {
     /**
      * Emitted when the http response headers have arrived.
      *
-     * @param event type of event (response)
-     * @param listener event listener to use
-     *
      * @event
      */
-    on(event: 'response', listener: HttpStreamResponse): this;
-
+    static RESPONSE = 'response';
 
     /**
      * Emitted when http response data is available.
      *
-     * @param event type of event (data)
-     * @param listener event listener to use
-     *
      * @event
      */
-    on(event: 'data', listener: HttpStreamData): this;
+    static DATA = 'data';
 
     /**
      * Emitted when an error occurs in stream processing
      *
-     * @param event type of event (error)
-     * @param listener event listener to use
-     *
      * @event
      */
-    on(event: 'error', listener: HttpStreamError): this;
+    static ERROR = 'error';
 
     /**
      * Emitted when the stream has completed
      *
-     * @param event type of event (end)
-     * @param listener event listener to use
-     *
      * @event
      */
-    on(event: 'end', listener: HttpStreamComplete): this;
+    static END = 'end';
 
     /**
      * Emitted when inline headers are delivered while communicating over H2
      *
-     * @param event type of event (headers)
-     * @param listener event listener to use
-     *
      * @event
-    */
+     */
+    static HEADERS = 'headers';
+
+    on(event: 'response', listener: HttpStreamResponse): this;
+
+    on(event: 'data', listener: HttpStreamData): this;
+
+    on(event: 'error', listener: HttpStreamError): this;
+
+    on(event: 'end', listener: HttpStreamComplete): this;
+
     on(event: 'headers', listener: HttpStreamHeaders): this;
 
     // Overridden to allow uncorking on ready and response

--- a/lib/native/http.ts
+++ b/lib/native/http.ts
@@ -349,7 +349,6 @@ export class HttpStream extends NativeResourceMixin(BufferedEventEmitter) implem
  *
  * @param headers the set of headers
  *
- * @asMemberOf HttpClientStream
  * @category HTTP
  */
 export type HttpStreamHeaders = (headers: HttpHeaders) => void;
@@ -360,7 +359,6 @@ export type HttpStreamHeaders = (headers: HttpHeaders) => void;
  * @param status_code http response status code
  * @param headers the response's set of headers
  *
- * @asMemberOf HttpClientStream
  * @category HTTP
  */
 export type HttpStreamResponse = (status_code: number, headers: HttpHeaders) => void;

--- a/lib/native/io.ts
+++ b/lib/native/io.ts
@@ -5,8 +5,18 @@
 
 /**
  *
+ * A module containing a grab bag of support for core network I/O functionality, including sockets, TLS, DNS, logging,
+ * error handling, streams, and connection -> thread mapping.
+ *
+ * Categories include:
+ * - Network: socket configuration
+ * - TLS: tls configuration
+ * - Logging: logging controls and configuration
+ * - IO: everything else
+ *
  * @packageDocumentation
- * @module IO
+ * @module io
+ * @mergeTarget
  */
 
 import crt_native from './binding';

--- a/lib/native/mqtt.ts
+++ b/lib/native/mqtt.ts
@@ -4,8 +4,12 @@
  */
 
 /**
+ *
+ * A module containing support for mqtt connection establishment and operations.
+ *
  * @packageDocumentation
  * @module mqtt
+ * @mergeTarget
  */
 
 import crt_native, { StringLike } from './binding';
@@ -24,13 +28,32 @@ import {
     OnMessageCallback,
     MqttConnectionConnected,
     MqttConnectionDisconnected,
-    MqttConnectionError,
-    MqttConnectionInterrupted,
     MqttConnectionResumed,
     DEFAULT_RECONNECT_MIN_SEC,
     DEFAULT_RECONNECT_MAX_SEC,
 } from "../common/mqtt";
 export { QoS, Payload, MqttRequest, MqttSubscribeRequest, MqttWill, OnMessageCallback } from "../common/mqtt";
+
+/**
+ * Listener signature for event emitted from an {@link MqttClientConnection} when an error occurs
+ *
+ * @param error the error that occurred
+ *
+ * @asMemberOf MqttClientConnection
+ * @category MQTT
+ */
+export type MqttConnectionError = (error: CrtError) => void;
+
+/**
+ * Listener signature for event emitted from an {@link MqttClientConnection} when the connection has been
+ * interrupted unexpectedly.
+ *
+ * @param error description of the error that occurred
+ *
+ * @asMemberOf MqttClientConnection
+ * @category MQTT
+ */
+export type MqttConnectionInterrupted = (error: CrtError) => void;
 
 /**
  * MQTT client
@@ -256,63 +279,57 @@ export class MqttClientConnection extends NativeResourceMixin(BufferedEventEmitt
     /**
      * Emitted when the connection successfully establishes itself for the first time
      *
-     * @param event the type of event (connect)
-     * @param listener the event listener to use
-     *
      * @event
      */
-    on(event: 'connect', listener: MqttConnectionConnected): this;
+    static CONNECT = 'connect';
 
     /**
      * Emitted when connection has disconnected sucessfully.
      *
-     * @param event the type of event (disconnect)
-     * @param listener the event listener to use
-     *
      * @event
      */
-    on(event: 'disconnect', listener: MqttConnectionDisconnected): this;
+    static DISCONNECT = 'disconnect';
 
     /**
      * Emitted when an error occurs.  The error will contain the error
      * code and message.
      *
-     * @param event the type of event (error)
-     * @param listener the event listener to use
-     *
      * @event
      */
-    on(event: 'error', listener: MqttConnectionError): this;
+    static ERROR = 'error';
 
     /**
      * Emitted when the connection is dropped unexpectedly. The error will contain the error
      * code and message.  The underlying mqtt implementation will attempt to reconnect.
      *
-     * @param event the type of event (interrupt)
-     * @param listener the event listener to use
-     *
      * @event
      */
-    on(event: 'interrupt', listener: MqttConnectionInterrupted): this;
+    static INTERRUPT = 'interrupt';
 
     /**
      * Emitted when the connection reconnects (after an interrupt). Only triggers on connections after the initial one.
      *
-     * @param event the type of event (resume)
-     * @param listener the event listener to use
-     *
      * @event
      */
-    on(event: 'resume', listener: MqttConnectionResumed): this;
+    static RESUME = 'resume';
 
     /**
      * Emitted when any MQTT publish message arrives.
      *
-     * @param event the type of event (message)
-     * @param listener the event listener to use
-     *
      * @event
      */
+    static MESSAGE = 'message';
+
+    on(event: 'connect', listener: MqttConnectionConnected): this;
+
+    on(event: 'disconnect', listener: MqttConnectionDisconnected): this;
+
+    on(event: 'error', listener: MqttConnectionError): this;
+
+    on(event: 'interrupt', listener: MqttConnectionInterrupted): this;
+
+    on(event: 'resume', listener: MqttConnectionResumed): this;
+
     on(event: 'message', listener: OnMessageCallback): this;
 
     // Overridden to allow uncorking on ready

--- a/lib/native/mqtt.ts
+++ b/lib/native/mqtt.ts
@@ -39,7 +39,6 @@ export { QoS, Payload, MqttRequest, MqttSubscribeRequest, MqttWill, OnMessageCal
  *
  * @param error the error that occurred
  *
- * @asMemberOf MqttClientConnection
  * @category MQTT
  */
 export type MqttConnectionError = (error: CrtError) => void;
@@ -50,7 +49,6 @@ export type MqttConnectionError = (error: CrtError) => void;
  *
  * @param error description of the error that occurred
  *
- * @asMemberOf MqttClientConnection
  * @category MQTT
  */
 export type MqttConnectionInterrupted = (error: CrtError) => void;

--- a/lib/native/mqtt.ts
+++ b/lib/native/mqtt.ts
@@ -493,7 +493,7 @@ export class MqttClientConnection extends NativeResourceMixin(BufferedEventEmitt
         this.emit('message', topic, payload, dup, qos, retain);
     }
 
-    private _on_connect_callback(resolve : (value?: (boolean | PromiseLike<boolean> | undefined)) => void, reject : (reason?: any) => void, error_code: number, return_code: number, session_present: boolean) {
+    private _on_connect_callback(resolve : (value: (boolean | PromiseLike<boolean>)) => void, reject : (reason?: any) => void, error_code: number, return_code: number, session_present: boolean) {
         if (error_code == 0 && return_code == 0) {
             resolve(session_present);
             this.emit('connect', session_present);
@@ -504,7 +504,7 @@ export class MqttClientConnection extends NativeResourceMixin(BufferedEventEmitt
         }
     }
 
-    private _on_puback_callback(resolve : (value?: (MqttRequest | PromiseLike<MqttRequest> | undefined)) => void, reject : (reason?: any) => void, packet_id: number, error_code: number) {
+    private _on_puback_callback(resolve : (value: (MqttRequest | PromiseLike<MqttRequest>)) => void, reject : (reason?: any) => void, packet_id: number, error_code: number) {
         if (error_code == 0) {
             resolve({ packet_id });
         } else {
@@ -512,7 +512,7 @@ export class MqttClientConnection extends NativeResourceMixin(BufferedEventEmitt
         }
     }
 
-    private _on_suback_callback(resolve : (value?: (MqttSubscribeRequest | PromiseLike<MqttSubscribeRequest> | undefined)) => void, reject : (reason?: any) => void, packet_id: number, topic: string, qos: QoS, error_code: number) {
+    private _on_suback_callback(resolve : (value: (MqttSubscribeRequest | PromiseLike<MqttSubscribeRequest>)) => void, reject : (reason?: any) => void, packet_id: number, topic: string, qos: QoS, error_code: number) {
         if (error_code == 0) {
             resolve({ packet_id, topic, qos, error_code });
         } else {
@@ -520,7 +520,7 @@ export class MqttClientConnection extends NativeResourceMixin(BufferedEventEmitt
         }
     }
 
-    private _on_unsuback_callback(resolve : (value?: (MqttRequest | PromiseLike<MqttRequest> | undefined)) => void, reject : (reason?: any) => void, packet_id: number, error_code: number) {
+    private _on_unsuback_callback(resolve : (value: (MqttRequest | PromiseLike<MqttRequest>)) => void, reject : (reason?: any) => void, packet_id: number, error_code: number) {
         if (error_code == 0) {
             resolve({ packet_id });
         } else {
@@ -528,7 +528,7 @@ export class MqttClientConnection extends NativeResourceMixin(BufferedEventEmitt
         }
     }
 
-    private _on_disconnect_callback(resolve: (value?: (void | PromiseLike<void> | undefined )) => void) {
+    private _on_disconnect_callback(resolve: (value?: (void | PromiseLike<void>)) => void) {
         resolve();
         this.emit('disconnect');
         this.close();

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,6 @@
         "puppeteer": "^3.3.0",
         "ts-jest": "^27.0.5",
         "typedoc": "^0.22.18",
-        "typedoc-plugin-as-member-of": "^1.0.2",
         "typedoc-plugin-merge-modules": "^3.1.0",
         "typescript": "^4.7.4",
         "uuid": "^8.3.2",
@@ -5789,15 +5788,6 @@
         "typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x || 4.6.x || 4.7.x"
       }
     },
-    "node_modules/typedoc-plugin-as-member-of": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-as-member-of/-/typedoc-plugin-as-member-of-1.0.2.tgz",
-      "integrity": "sha512-M7nC4i42HOGmbZValMq99Uh5gNJoaOYif5/p/CQR3kXOD3E1qaPu1Aj1MHdRwHE2V1yUeeEbILQVMMkkLJ4JuQ==",
-      "dev": true,
-      "peerDependencies": {
-        "typedoc": ">=0.7 <1.11.1"
-      }
-    },
     "node_modules/typedoc-plugin-merge-modules": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/typedoc-plugin-merge-modules/-/typedoc-plugin-merge-modules-3.1.0.tgz",
@@ -10927,13 +10917,6 @@
           }
         }
       }
-    },
-    "typedoc-plugin-as-member-of": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-as-member-of/-/typedoc-plugin-as-member-of-1.0.2.tgz",
-      "integrity": "sha512-M7nC4i42HOGmbZValMq99Uh5gNJoaOYif5/p/CQR3kXOD3E1qaPu1Aj1MHdRwHE2V1yUeeEbILQVMMkkLJ4JuQ==",
-      "dev": true,
-      "requires": {}
     },
     "typedoc-plugin-merge-modules": {
       "version": "3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,8 @@
         "puppeteer": "^3.3.0",
         "ts-jest": "^27.0.5",
         "typedoc": "^0.22.18",
+        "typedoc-plugin-as-member-of": "^1.0.2",
+        "typedoc-plugin-merge-modules": "^3.1.0",
         "typescript": "^4.7.4",
         "uuid": "^8.3.2",
         "yargs": "^17.2.1"
@@ -5787,6 +5789,24 @@
         "typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x || 4.6.x || 4.7.x"
       }
     },
+    "node_modules/typedoc-plugin-as-member-of": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-as-member-of/-/typedoc-plugin-as-member-of-1.0.2.tgz",
+      "integrity": "sha512-M7nC4i42HOGmbZValMq99Uh5gNJoaOYif5/p/CQR3kXOD3E1qaPu1Aj1MHdRwHE2V1yUeeEbILQVMMkkLJ4JuQ==",
+      "dev": true,
+      "peerDependencies": {
+        "typedoc": ">=0.7 <1.11.1"
+      }
+    },
+    "node_modules/typedoc-plugin-merge-modules": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-merge-modules/-/typedoc-plugin-merge-modules-3.1.0.tgz",
+      "integrity": "sha512-DAHDZD+KG3mRm+hJFAMh/pO98CQ3W/BFA81FzWpc1kos66mLRIa7QVO30yBREkZNZMsTA7fgGEjEN2GO2cgi3A==",
+      "dev": true,
+      "peerDependencies": {
+        "typedoc": "0.21.x || 0.22.x"
+      }
+    },
     "node_modules/typedoc/node_modules/brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -10907,6 +10927,20 @@
           }
         }
       }
+    },
+    "typedoc-plugin-as-member-of": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-as-member-of/-/typedoc-plugin-as-member-of-1.0.2.tgz",
+      "integrity": "sha512-M7nC4i42HOGmbZValMq99Uh5gNJoaOYif5/p/CQR3kXOD3E1qaPu1Aj1MHdRwHE2V1yUeeEbILQVMMkkLJ4JuQ==",
+      "dev": true,
+      "requires": {}
+    },
+    "typedoc-plugin-merge-modules": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-merge-modules/-/typedoc-plugin-merge-modules-3.1.0.tgz",
+      "integrity": "sha512-DAHDZD+KG3mRm+hJFAMh/pO98CQ3W/BFA81FzWpc1kos66mLRIa7QVO30yBREkZNZMsTA7fgGEjEN2GO2cgi3A==",
+      "dev": true,
+      "requires": {}
     },
     "typescript": {
       "version": "4.7.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@types/crypto-js": "^3.1.43",
         "@types/jest": "^27.0.1",
         "@types/node": "^10.17.54",
+        "@types/prettier": "2.6.0",
         "@types/puppeteer": "^5.4.4",
         "@types/uuid": "^3.4.8",
         "@types/ws": "^7.4.7",
@@ -32,11 +33,8 @@
         "jest-runtime": "^27.2.1",
         "puppeteer": "^3.3.0",
         "ts-jest": "^27.0.5",
-        "typedoc": "^0.17.8",
-        "typedoc-plugin-as-member-of": "^1.0.2",
-        "typedoc-plugin-external-module-name": "^4.0.6",
-        "typedoc-plugin-remove-references": "^0.0.5",
-        "typescript": "^3.9.9",
+        "typedoc": "^0.22.18",
+        "typescript": "^4.7.4",
         "uuid": "^8.3.2",
         "yargs": "^17.2.1"
       }
@@ -2898,27 +2896,6 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
     },
-    "node_modules/handlebars": {
-      "version": "4.7.7",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
-      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.5",
-        "neo-async": "^2.6.0",
-        "source-map": "^0.6.1",
-        "wordwrap": "^1.0.0"
-      },
-      "bin": {
-        "handlebars": "bin/handlebars"
-      },
-      "engines": {
-        "node": ">=0.4.7"
-      },
-      "optionalDependencies": {
-        "uglify-js": "^3.1.4"
-      }
-    },
     "node_modules/has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -2965,15 +2942,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/highlight.js": {
-      "version": "10.7.3",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
-      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
-      "dev": true,
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/homedir-polyfill": {
@@ -3105,15 +3073,6 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
-    },
-    "node_modules/interpret": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.10"
-      }
     },
     "node_modules/invert-kv": {
       "version": "1.0.0",
@@ -4144,6 +4103,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
+      "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
+      "dev": true
+    },
     "node_modules/jsonfile": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
@@ -4321,15 +4286,15 @@
       }
     },
     "node_modules/marked": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-1.0.0.tgz",
-      "integrity": "sha512-Wo+L1pWTVibfrSr+TTtMuiMfNzmZWiOPeO7rZsQUY5bgsxpHesBEcIWJloWVTFnrMXnf/TL30eTFSGJddmQAng==",
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.17.tgz",
+      "integrity": "sha512-Wfk0ATOK5iPxM4ptrORkFemqroz0ZDxp5MWfYA7H/F+wO17NRWV5Ypxi6p3g2Xmw2bKeiYOl6oVnLHKxBA0VhA==",
       "dev": true,
       "bin": {
-        "marked": "bin/marked"
+        "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 8.16.2"
+        "node": ">= 12"
       }
     },
     "node_modules/memory-stream": {
@@ -4589,12 +4554,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-      "dev": true
-    },
-    "node_modules/neo-async": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
     "node_modules/node-int64": {
@@ -5063,18 +5022,6 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
-    "node_modules/rechoir": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
-      "dev": true,
-      "dependencies": {
-        "resolve": "^1.1.6"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/reinterval": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reinterval/-/reinterval-1.1.0.tgz",
@@ -5294,21 +5241,15 @@
         "node": ">=8"
       }
     },
-    "node_modules/shelljs": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
-      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+    "node_modules/shiki": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.10.1.tgz",
+      "integrity": "sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==",
       "dev": true,
       "dependencies": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
-      },
-      "bin": {
-        "shjs": "bin/shjs"
-      },
-      "engines": {
-        "node": ">=4"
+        "jsonc-parser": "^3.0.0",
+        "vscode-oniguruma": "^1.6.1",
+        "vscode-textmate": "5.2.0"
       }
     },
     "node_modules/signal-exit": {
@@ -5825,105 +5766,71 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.17.8",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.17.8.tgz",
-      "integrity": "sha512-/OyrHCJ8jtzu+QZ+771YaxQ9s4g5Z3XsQE3Ma7q+BL392xxBn4UMvvCdVnqKC2T/dz03/VXSLVKOP3lHmDdc/w==",
+      "version": "0.22.18",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.18.tgz",
+      "integrity": "sha512-NK9RlLhRUGMvc6Rw5USEYgT4DVAUFk7IF7Q6MYfpJ88KnTZP7EneEa4RcP+tX1auAcz7QT1Iy0bUSZBYYHdoyA==",
       "dev": true,
       "dependencies": {
-        "fs-extra": "^8.1.0",
-        "handlebars": "^4.7.6",
-        "highlight.js": "^10.0.0",
-        "lodash": "^4.17.15",
-        "lunr": "^2.3.8",
-        "marked": "1.0.0",
-        "minimatch": "^3.0.0",
-        "progress": "^2.0.3",
-        "shelljs": "^0.8.4",
-        "typedoc-default-themes": "^0.10.2"
+        "glob": "^8.0.3",
+        "lunr": "^2.3.9",
+        "marked": "^4.0.16",
+        "minimatch": "^5.1.0",
+        "shiki": "^0.10.1"
       },
       "bin": {
         "typedoc": "bin/typedoc"
       },
       "engines": {
-        "node": ">= 8.0.0"
+        "node": ">= 12.10.0"
       },
       "peerDependencies": {
-        "typescript": ">=3.8.3"
+        "typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x || 4.6.x || 4.7.x"
       }
     },
-    "node_modules/typedoc-default-themes": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.10.2.tgz",
-      "integrity": "sha512-zo09yRj+xwLFE3hyhJeVHWRSPuKEIAsFK5r2u47KL/HBKqpwdUSanoaz5L34IKiSATFrjG5ywmIu98hPVMfxZg==",
+    "node_modules/typedoc/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
       "dependencies": {
-        "lunr": "^2.3.8"
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/typedoc/node_modules/glob": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
+      "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
       },
       "engines": {
-        "node": ">= 8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/typedoc-plugin-as-member-of": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-as-member-of/-/typedoc-plugin-as-member-of-1.0.2.tgz",
-      "integrity": "sha512-M7nC4i42HOGmbZValMq99Uh5gNJoaOYif5/p/CQR3kXOD3E1qaPu1Aj1MHdRwHE2V1yUeeEbILQVMMkkLJ4JuQ==",
-      "dev": true,
-      "peerDependencies": {
-        "typedoc": ">=0.7 <1.11.1"
-      }
-    },
-    "node_modules/typedoc-plugin-external-module-name": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-external-module-name/-/typedoc-plugin-external-module-name-4.0.6.tgz",
-      "integrity": "sha512-WqJW5gbfeQD7VA96p5eRFkVlPPGXfpaAo7M/sNOeBwSBTRylKYX15kAVaGP6iM/VhXtDagTMyKhwG97sENfKHA==",
+    "node_modules/typedoc/node_modules/minimatch": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
       "dev": true,
       "dependencies": {
-        "lodash": "^4.1.2",
-        "semver": "^7.1.1"
-      },
-      "peerDependencies": {
-        "typedoc": ">=0.7.0 <0.20.0"
-      }
-    },
-    "node_modules/typedoc-plugin-external-module-name/node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
+        "brace-expansion": "^2.0.1"
       },
       "engines": {
         "node": ">=10"
       }
     },
-    "node_modules/typedoc-plugin-remove-references": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-remove-references/-/typedoc-plugin-remove-references-0.0.5.tgz",
-      "integrity": "sha512-DSZ7kM/Y90CgZUKt8MiDsoi4fvrJyleHydj3ncGyqDqMdhuMes2E/4I6mSmXBrVdTjYhVH6BeoOFSbj2pQ821g==",
-      "dev": true
-    },
-    "node_modules/typedoc/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
     "node_modules/typescript": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -5931,19 +5838,6 @@
       },
       "engines": {
         "node": ">=4.2.0"
-      }
-    },
-    "node_modules/uglify-js": {
-      "version": "3.15.5",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.5.tgz",
-      "integrity": "sha512-hNM5q5GbBRB5xB+PMqVRcgYe4c8jbyZ1pzZhS6jbq54/4F2gFK869ZheiE5A8/t+W5jtTNpWef/5Q9zk639FNQ==",
-      "dev": true,
-      "optional": true,
-      "bin": {
-        "uglifyjs": "bin/uglifyjs"
-      },
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/unbzip2-stream": {
@@ -6085,6 +5979,18 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/vscode-oniguruma": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
+      "integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==",
+      "dev": true
+    },
+    "node_modules/vscode-textmate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
+      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
+      "dev": true
     },
     "node_modules/w3c-hr-time": {
       "version": "1.0.2",
@@ -6306,12 +6212,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-      "dev": true
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
@@ -8715,19 +8615,6 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
     },
-    "handlebars": {
-      "version": "4.7.7",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
-      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.5",
-        "neo-async": "^2.6.0",
-        "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4",
-        "wordwrap": "^1.0.0"
-      }
-    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -8768,12 +8655,6 @@
           }
         }
       }
-    },
-    "highlight.js": {
-      "version": "10.7.3",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
-      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
-      "dev": true
     },
     "homedir-polyfill": {
       "version": "1.0.3",
@@ -8874,12 +8755,6 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
-    },
-    "interpret": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
-      "dev": true
     },
     "invert-kv": {
       "version": "1.0.0",
@@ -9688,6 +9563,12 @@
       "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
       "dev": true
     },
+    "jsonc-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
+      "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
+      "dev": true
+    },
     "jsonfile": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
@@ -9834,9 +9715,9 @@
       }
     },
     "marked": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-1.0.0.tgz",
-      "integrity": "sha512-Wo+L1pWTVibfrSr+TTtMuiMfNzmZWiOPeO7rZsQUY5bgsxpHesBEcIWJloWVTFnrMXnf/TL30eTFSGJddmQAng==",
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.17.tgz",
+      "integrity": "sha512-Wfk0ATOK5iPxM4ptrORkFemqroz0ZDxp5MWfYA7H/F+wO17NRWV5Ypxi6p3g2Xmw2bKeiYOl6oVnLHKxBA0VhA==",
       "dev": true
     },
     "memory-stream": {
@@ -10049,12 +9930,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-      "dev": true
-    },
-    "neo-async": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
     "node-int64": {
@@ -10423,15 +10298,6 @@
         }
       }
     },
-    "rechoir": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
-      "dev": true,
-      "requires": {
-        "resolve": "^1.1.6"
-      }
-    },
     "reinterval": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reinterval/-/reinterval-1.1.0.tgz",
@@ -10588,15 +10454,15 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
-    "shelljs": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
-      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+    "shiki": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.10.1.tgz",
+      "integrity": "sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==",
       "dev": true,
       "requires": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
+        "jsonc-parser": "^3.0.0",
+        "vscode-oniguruma": "^1.6.1",
+        "vscode-textmate": "5.2.0"
       }
     },
     "signal-exit": {
@@ -10997,91 +10863,56 @@
       }
     },
     "typedoc": {
-      "version": "0.17.8",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.17.8.tgz",
-      "integrity": "sha512-/OyrHCJ8jtzu+QZ+771YaxQ9s4g5Z3XsQE3Ma7q+BL392xxBn4UMvvCdVnqKC2T/dz03/VXSLVKOP3lHmDdc/w==",
+      "version": "0.22.18",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.18.tgz",
+      "integrity": "sha512-NK9RlLhRUGMvc6Rw5USEYgT4DVAUFk7IF7Q6MYfpJ88KnTZP7EneEa4RcP+tX1auAcz7QT1Iy0bUSZBYYHdoyA==",
       "dev": true,
       "requires": {
-        "fs-extra": "^8.1.0",
-        "handlebars": "^4.7.6",
-        "highlight.js": "^10.0.0",
-        "lodash": "^4.17.15",
-        "lunr": "^2.3.8",
-        "marked": "1.0.0",
-        "minimatch": "^3.0.0",
-        "progress": "^2.0.3",
-        "shelljs": "^0.8.4",
-        "typedoc-default-themes": "^0.10.2"
+        "glob": "^8.0.3",
+        "lunr": "^2.3.9",
+        "marked": "^4.0.16",
+        "minimatch": "^5.1.0",
+        "shiki": "^0.10.1"
       },
       "dependencies": {
-        "fs-extra": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "glob": {
+          "version": "8.0.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
+          "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^5.0.1",
+            "once": "^1.3.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+          "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
           }
         }
       }
-    },
-    "typedoc-default-themes": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.10.2.tgz",
-      "integrity": "sha512-zo09yRj+xwLFE3hyhJeVHWRSPuKEIAsFK5r2u47KL/HBKqpwdUSanoaz5L34IKiSATFrjG5ywmIu98hPVMfxZg==",
-      "dev": true,
-      "requires": {
-        "lunr": "^2.3.8"
-      }
-    },
-    "typedoc-plugin-as-member-of": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-as-member-of/-/typedoc-plugin-as-member-of-1.0.2.tgz",
-      "integrity": "sha512-M7nC4i42HOGmbZValMq99Uh5gNJoaOYif5/p/CQR3kXOD3E1qaPu1Aj1MHdRwHE2V1yUeeEbILQVMMkkLJ4JuQ==",
-      "dev": true,
-      "requires": {}
-    },
-    "typedoc-plugin-external-module-name": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-external-module-name/-/typedoc-plugin-external-module-name-4.0.6.tgz",
-      "integrity": "sha512-WqJW5gbfeQD7VA96p5eRFkVlPPGXfpaAo7M/sNOeBwSBTRylKYX15kAVaGP6iM/VhXtDagTMyKhwG97sENfKHA==",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.1.2",
-        "semver": "^7.1.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.3.7",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
-      }
-    },
-    "typedoc-plugin-remove-references": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-remove-references/-/typedoc-plugin-remove-references-0.0.5.tgz",
-      "integrity": "sha512-DSZ7kM/Y90CgZUKt8MiDsoi4fvrJyleHydj3ncGyqDqMdhuMes2E/4I6mSmXBrVdTjYhVH6BeoOFSbj2pQ821g==",
-      "dev": true
     },
     "typescript": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "dev": true
-    },
-    "uglify-js": {
-      "version": "3.15.5",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.5.tgz",
-      "integrity": "sha512-hNM5q5GbBRB5xB+PMqVRcgYe4c8jbyZ1pzZhS6jbq54/4F2gFK869ZheiE5A8/t+W5jtTNpWef/5Q9zk639FNQ==",
-      "dev": true,
-      "optional": true
     },
     "unbzip2-stream": {
       "version": "1.4.3",
@@ -11204,6 +11035,18 @@
           "dev": true
         }
       }
+    },
+    "vscode-oniguruma": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
+      "integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==",
+      "dev": true
+    },
+    "vscode-textmate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
+      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
+      "dev": true
     },
     "w3c-hr-time": {
       "version": "1.0.2",
@@ -11380,12 +11223,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-      "dev": true
-    },
-    "wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
     },
     "wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "puppeteer": "^3.3.0",
     "ts-jest": "^27.0.5",
     "typedoc": "^0.22.18",
+    "typedoc-plugin-as-member-of": "^1.0.2",
+    "typedoc-plugin-merge-modules": "^3.1.0",
     "typescript": "^4.7.4",
     "uuid": "^8.3.2",
     "yargs": "^17.2.1"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "puppeteer": "^3.3.0",
     "ts-jest": "^27.0.5",
     "typedoc": "^0.22.18",
-    "typedoc-plugin-as-member-of": "^1.0.2",
     "typedoc-plugin-merge-modules": "^3.1.0",
     "typescript": "^4.7.4",
     "uuid": "^8.3.2",

--- a/package.json
+++ b/package.json
@@ -36,11 +36,8 @@
     "jest-runtime": "^27.2.1",
     "puppeteer": "^3.3.0",
     "ts-jest": "^27.0.5",
-    "typedoc": "^0.17.8",
-    "typedoc-plugin-as-member-of": "^1.0.2",
-    "typedoc-plugin-external-module-name": "^4.0.6",
-    "typedoc-plugin-remove-references": "^0.0.5",
-    "typescript": "^3.9.9",
+    "typedoc": "^0.22.18",
+    "typescript": "^4.7.4",
     "uuid": "^8.3.2",
     "yargs": "^17.2.1"
   },

--- a/samples/browser/http/package.json
+++ b/samples/browser/http/package.json
@@ -18,12 +18,13 @@
     "url": "https://github.com/awslabs/aws-crt-nodejs/issues"
   },
   "devDependencies": {
+    "node-polyfill-webpack-plugin": "^1.1.4",
     "@types/jquery": "^3.3.30",
-    "source-map-loader": "^0.2.4",
-    "ts-loader": "^6.2.1",
-    "typescript": "^3.7.3",
-    "webpack": "^5.52.0",
-    "webpack-cli": "^4.8.0"
+    "source-map-loader": "^4.0.0",
+    "ts-loader": "^9.3.1",
+    "typescript": "^4.7.4",
+    "webpack": "^5.73.0",
+    "webpack-cli": "^4.10.0"
   },
   "dependencies": {
     "aws-crt": "file:../../../",

--- a/samples/browser/http/webpack.config.js
+++ b/samples/browser/http/webpack.config.js
@@ -1,3 +1,5 @@
+const NodePolyfillPlugin = require("node-polyfill-webpack-plugin")
+
 module.exports = {
     entry: "./index.ts",
     devtool: "source-map",
@@ -13,5 +15,8 @@ module.exports = {
             // all files with a '.ts' or '.tsx' extension will be handled by 'ts-loader'
             { test: /\.tsx?$/, use: ["ts-loader"], exclude: /node_modules/ }
         ]
-    }
+    },
+    plugins: [
+        new NodePolyfillPlugin()
+    ]
 }

--- a/samples/browser/pub_sub/package.json
+++ b/samples/browser/pub_sub/package.json
@@ -20,11 +20,11 @@
   "devDependencies": {
     "@types/jquery": "^3.3.31",
     "node-polyfill-webpack-plugin": "^1.1.4",
-    "source-map-loader": "^0.2.4",
-    "ts-loader": "^6.2.1",
-    "typescript": "^3.7.3",
-    "webpack": "^5.59.1",
-    "webpack-cli": "^4.9.1"
+    "source-map-loader": "^4.0.0",
+    "ts-loader": "^9.3.1",
+    "typescript": "^4.7.4",
+    "webpack": "^5.73.0",
+    "webpack-cli": "^4.10.0"
   },
   "dependencies": {
     "aws-crt": "file:../../../",

--- a/samples/node/elasticurl/package.json
+++ b/samples/node/elasticurl/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/awslabs/aws-crt-nodejs#readme",
   "devDependencies": {
     "@types/node": "^10.17.17",
-    "typescript": "^3.8.3"
+    "typescript": "^4.7.4"
   },
   "dependencies": {
     "aws-crt": "file:../../../",


### PR DESCRIPTION
* Update typescript to latest
* Update typedoc to almost-latest MV
* Update typedoc config to account for all the breaking changes
* Swap typedoc plugins to modern ones that still work and do approximately what we had plugins doing before.
* Rework how events are documented
* Move some private browser mqtt connection functionality to the bottom of the class definition
* Move some problematic type definitions that used CrtError (which is defined in browser/native) down to browser/native
* Expose checksums as an export
* Fix some messy type errors due to stricter checking in 4.x
* Update sample package.jsons

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
