### PR TITLE
Remove unused 'ws' dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,8 +16,7 @@
         "crypto-js": "^4.0.0",
         "fastestsmallesttextencoderdecoder": "^1.0.22",
         "mqtt": "^4.3.7",
-        "tar": "^6.1.11",
-        "ws": "^7.5.5"
+        "tar": "^6.1.11"
       },
       "devDependencies": {
         "@types/crypto-js": "^3.1.43",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "crypto-js": "^4.0.0",
     "fastestsmallesttextencoderdecoder": "^1.0.22",
     "mqtt": "^4.3.7",
-    "tar": "^6.1.11",
-    "ws": "^7.5.5"
+    "tar": "^6.1.11"
   }
 }


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/awslabs/aws-crt-nodejs/issues/333

*Description of changes:*
The usage of 'ws' dependency was removed in https://github.com/awslabs/aws-crt-nodejs/pull/282, but dependency itself was not removed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
