### PR TITLE
Fix reconnect and disconnect behaviors in browser mqtt client wrapper

### DIFF
--- a/lib/browser/mqtt.ts
+++ b/lib/browser/mqtt.ts
@@ -274,7 +274,7 @@ export class MqttClientConnection extends BufferedEventEmitter {
 
     private currentState: MqttBrowserClientState = MqttBrowserClientState.Stopped;
     private desiredState: MqttBrowserClientState = MqttBrowserClientState.Stopped;
-    private reconnectTask?: NodeJS.Timer;
+    private reconnectTask?: ReturnType<typeof setTimeout>;
 
     /**
      * @param client The client that owns this connection

--- a/lib/browser/mqtt.ts
+++ b/lib/browser/mqtt.ts
@@ -569,7 +569,10 @@ export class MqttClientConnection extends BufferedEventEmitter {
     }
 
     private on_close = () => {
-        /* Only emit an interruption event if we were connected, otherwise we just failed to reconnect */
+        /*
+         * Only emit an interruption event if we were connected, otherwise we just failed to reconnect after
+         * a disconnection.
+         */
         if (this.currentState == MqttBrowserClientState.Connected) {
             this.currentState = MqttBrowserClientState.Stopped;
             this.emit('interrupt', -1);

--- a/lib/browser/mqtt.ts
+++ b/lib/browser/mqtt.ts
@@ -575,7 +575,7 @@ export class MqttClientConnection extends BufferedEventEmitter {
             this.emit('interrupt', -1);
         }
 
-        /* Only try and reconnect if our desired state is connected -- no one has called disconnect() */
+        /* Only try and reconnect if our desired state is connected, ie no one has called disconnect() */
         if (this.desiredState == MqttBrowserClientState.Connected) {
             const waitTime = this.get_reconnect_time_sec();
             this.reconnectTask = setTimeout(() => {


### PR DESCRIPTION
* Variable-length reconnect (exponential backoff) was not working properly because the offline event only fires once, not each connection failure/disconnection.  To properly implement exponential backoff, we must use the close event, which fires every connection failure/disconnection.  We must also model additional connection state (desired, current) in order to properly react to the close event.
* The disconnect promise was not getting completed.  The mqtt-js disconnect implementation has many complexities most likely due to backwards compatibility contracts.  This update fixes this issue in a backwards compatible manner.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
