### PR TITLE
fix our release pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test:browser": "npx jest --runInBand --verbose --config test/browser/jest.config.js --forceExit",
     "test:browser:ci": "npm run install:puppeteer && npm run test:browser",
     "install:puppeteer": "npm install --save-dev jest-puppeteer puppeteer @types/puppeteer",
-    "prepare": "node ./scripts/tsc.js && node ./scripts/install.js",
+    "prepare": "node ./scripts/tsc.js",
     "install": "node ./scripts/install.js"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test:browser": "npx jest --runInBand --verbose --config test/browser/jest.config.js --forceExit",
     "test:browser:ci": "npm run install:puppeteer && npm run test:browser",
     "install:puppeteer": "npm install --save-dev jest-puppeteer puppeteer @types/puppeteer",
-    "prepare": "node ./scripts/tsc.js",
+    "prepare": "node ./scripts/tsc.js && node ./scripts/install.js",
     "install": "node ./scripts/install.js"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "test:browser": "npx jest --runInBand --verbose --config test/browser/jest.config.js --forceExit",
     "test:browser:ci": "npm run install:puppeteer && npm run test:browser",
     "install:puppeteer": "npm install --save-dev jest-puppeteer puppeteer @types/puppeteer",
-    "prepare": "node ./scripts/tsc.js && node ./scripts/build.js",
-    "install": "node ./scripts/install.js --production"
+    "prepare": "node ./scripts/tsc.js",
+    "install": "node ./scripts/install.js"
   },
   "devDependencies": {
     "@types/crypto-js": "^3.1.43",

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -7,10 +7,13 @@ const process = require("process");
 const path = require("path");
 const fs = require("fs");
 
-const binaryDir = path.join('dist', 'bin', `${os.platform()}-${os.arch()}`, 'aws-crt-nodejs.node');
-if (fs.existsSync(binaryDir)) {
-    // Don't continue if the binding already exists (unless --rebuild is specified)
-    process.exit(0);
+if (!process.argv.includes('--rebuild')) {
+    const binaryDir = path.join('dist', 'bin', `${os.platform()}-${os.arch()}`, 'aws-crt-nodejs.node');
+    if (fs.existsSync(binaryDir)) {
+        // Don't continue if the binding already exists (unless --rebuild is specified)
+        console.log("The binding already exists, skip rebuilding. To rebuild the native addon, please run install.js with `--rebuild`")
+        process.exit(0);
+    }
 }
 
 // Run the build


### PR DESCRIPTION
*Issue #, if available:*

- Our pack stage of the release pipeline doesn't have Cmake, as it should not need to rebuild the native addon
- However the prepare script will always rebuild the native addon, which I doubt it's needed. At least for our release pipeline.
- Did a quick search about how people did for other nodejs lib with native addon. 
   - Some use prepare to build, but they don't have install eg: [react-pdf](https://github.com/diegomura/react-pdf/blob/master/package.json). So that if people run [npm-pack](https://docs.npmjs.com/cli/v8/using-npm/scripts#npm-pack) or publish, they will have the native addon available without install.
   - Some use install to build, and the prepare just do the tsc thing. eg: [Couchbase](https://github.com/couchbase/couchnode/blob/master/package.json). User will need to run npm install first in this case.

*Description of changes:*

- I think we should skip the build of native addon for the prepare script, maybe it's nice to have native addon available without `npm install`? I don't have strong feeling about it.
- Well, the other end, the reason for pack and publish is for us to publish the package, and we don't really want to just publish one prebuild binary. So, I don't think it really matters.
- Fix the lie about `--rebuild`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
