### PR TITLE
Fix build script not having globally defined nativeSourceDir

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -12,6 +12,8 @@ const cmake = require("cmake-js");
 const axios = require("axios");
 const tar = require("tar");
 
+const nativeSourceDir = "crt/";
+
 function rmRecursive(rmPath) {
     let rmBasePath = path.basename(rmPath);
     if (rmBasePath == "." || rmBasePath == "..") {
@@ -185,7 +187,6 @@ function checkDoDownload() {
     // Makes sure the work directory is what we need
     const workDir = path.join(__dirname, "../")
     process.chdir(workDir);
-    const nativeSourceDir = "crt/"
 
     if (checkDoDownload()) {
         const tmpPath = path.join(__dirname, `temp${crypto.randomBytes(16).toString("hex")}/`);


### PR DESCRIPTION
*Issue #, if available:*

Fixes #354

*Description of changes:*

Fixes `nativeSourceDir` not being globally defined, causing it to fail in functions outside of `main`.

__________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
