### PR TITLE
Use newer docker image when creating releases

### DIFF
--- a/continuous-delivery/build-manylinux2014-aarch64-jenkins.sh
+++ b/continuous-delivery/build-manylinux2014-aarch64-jenkins.sh
@@ -2,7 +2,7 @@
 #run build script in manylinux2014 docker image
 set -ex
 
-DOCKER_IMAGE=123124136734.dkr.ecr.us-east-1.amazonaws.com/aws-crt/manylinux2014-aarch64:latest
+DOCKER_IMAGE=123124136734.dkr.ecr.us-east-1.amazonaws.com/aws-crt-manylinux2014-aarch64:latest
 
 $(aws --region us-east-1 ecr get-login --no-include-email)
 


### PR DESCRIPTION
Nearly a year ago, aws-crt-builder changed the path where these docker images are uploaded to (see https://github.com/awslabs/aws-crt-builder/pull/153)

Use the newer path, instead of the old abandoned path

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
