### PR TITLE
Revert "Use newer docker image when creating releases (#363)"

### DIFF
--- a/continuous-delivery/build-manylinux2014-aarch64-jenkins.sh
+++ b/continuous-delivery/build-manylinux2014-aarch64-jenkins.sh
@@ -2,7 +2,7 @@
 #run build script in manylinux2014 docker image
 set -ex
 
-DOCKER_IMAGE=123124136734.dkr.ecr.us-east-1.amazonaws.com/aws-crt-manylinux2014-aarch64:latest
+DOCKER_IMAGE=123124136734.dkr.ecr.us-east-1.amazonaws.com/aws-crt/manylinux2014-aarch64:latest
 
 $(aws --region us-east-1 ecr get-login --no-include-email)
 


### PR DESCRIPTION
**Issue:**
The release pipeline of aws-crt-python broke when using this updated docker image. Reverting this change while we investigate the underlying cause...

**Description of changes:**
This reverts commit f0fb9e0065fbcbd8cdb7e4a7677475c8d70b7518.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
