### PR TITLE
Fix "dubious ownership" error from git, when running in docker using bind mounted directory

### DIFF
--- a/continuous-delivery/build-manylinux2014-aarch64-jenkins.sh
+++ b/continuous-delivery/build-manylinux2014-aarch64-jenkins.sh
@@ -8,8 +8,10 @@ $(aws --region us-east-1 ecr get-login --no-include-email)
 
 docker pull $DOCKER_IMAGE
 
+# NOTE: set --user to avoid "dubious ownership" errors from git in the bind mounted directory
 docker run --rm \
     --mount type=bind,source=`pwd`,target=/aws-crt-nodejs \
+    --user "$(id -u):$(id -g)" \
     --workdir /aws-crt-nodejs \
     --entrypoint /bin/bash \
     $DOCKER_IMAGE \


### PR DESCRIPTION
**Issue:**
This docker image uses a newer version of git. When running with a bind mounted directory, git fails with "dubious ownership" errors.

Newer versions of git fail if the current user doesn't match the owner of the `.git/` folder. Since the directory is bind mounted, it is owned by the user on the host OS. But within a container, the user is `root` by default. Since `root` doesn't match the owner of the `.git/` folder, git fails.

**Description of changes:**
Set `--user` to match the owner of the bind mounted directory.

See the original diagnosis of the issue here: https://github.com/awslabs/aws-crt-python/pull/404

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
