### PR TITLE
Handle expired STS token

### DIFF
--- a/lib/browser/mqtt.ts
+++ b/lib/browser/mqtt.ts
@@ -389,14 +389,16 @@ export class MqttClientConnection extends BufferedEventEmitter {
 
         setTimeout(() => { this.uncork() }, 0);
         return new Promise<boolean>((resolve, reject) => {
-            const on_connect_error = (error: Error) => {
-                reject(new CrtError(error));
+            const on_connect_error = (error?: Error) => {
+                reject(new CrtError(error || new Error("Failed to connect. Credentials might have expired.")));
             };
             this.connection.once('connect', (connack: mqtt.IConnackPacket) => {
                 this.connection.removeListener('error', on_connect_error);
+                this.connection.removeListener('end', on_connect_error);
                 resolve(connack.sessionPresent);
             });
             this.connection.once('error', on_connect_error);
+            this.connection.once('end', on_connect_error);
         });
     }
 


### PR DESCRIPTION
*Description of changes:*
async call to connect doesn't complete if credentials have expired. If token is expired the `MqttClient` will emit `end` event which currently not handled by the connection callbacks.

This PR also listens for end events and thus the promise completes with an error if the token is expired.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
