### PR TITLE
Fix release pipeline

### DIFF
--- a/continuous-delivery/build-manylinux2014-aarch64-jenkins.sh
+++ b/continuous-delivery/build-manylinux2014-aarch64-jenkins.sh
@@ -8,10 +8,8 @@ $(aws --region us-east-1 ecr get-login --no-include-email)
 
 docker pull $DOCKER_IMAGE
 
-# NOTE: set --user to avoid "dubious ownership" errors from git in the bind mounted directory
 docker run --rm \
     --mount type=bind,source=`pwd`,target=/aws-crt-nodejs \
-    --user "$(id -u):$(id -g)" \
     --workdir /aws-crt-nodejs \
     --entrypoint /bin/bash \
     $DOCKER_IMAGE \


### PR DESCRIPTION
**Issue:**
Release pipeline fails when running node in a docker image and *not* being the root user.

I'd previously made this change to fix any `git` calls we might make while running in the docker image, but turns out this task doesn't make any `git` calls

*Description of changes:*
This reverts commit 380028fbf21e27fa735f02b460b882a41a52a424.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
