### PR TITLE
bump package size limit

### DIFF
--- a/.builder/actions/crt_size_check.py
+++ b/.builder/actions/crt_size_check.py
@@ -8,7 +8,9 @@ import os
 
 class CrtSizeCheck(Builder.Action):
     def run(self, env):
-        # Maximum package size in bytes
+        # Maximum package size (for current platform) in bytes
+        # NOTE: if you increase this, you might also need to increase the
+        # limit in continuous-delivery/pack.sh
         max_size = 6_000_000
         # size of current folder
         folder_size = 0

--- a/.npmignore
+++ b/.npmignore
@@ -151,6 +151,7 @@ deps_build/
 .vscode/
 
 # Skip source-only files
+/canary/
 /lib/
 /test/
 /samples/

--- a/continuous-delivery/pack.sh
+++ b/continuous-delivery/pack.sh
@@ -38,8 +38,8 @@ UNZIP="unzip_pack"
 mkdir $UNZIP
 tar -xf aws-crt-$CURRENT_TAG.tgz -C $UNZIP
 PACK_FILE_SIZE_KB=$(du -sk $UNZIP | awk '{print $1}')
-if expr $PACK_FILE_SIZE_KB \> "$((14 * 1024))" ; then
-    # the package size is larger than 14 MB, return -1
+if expr $PACK_FILE_SIZE_KB \> "$((15000))" ; then
+    # the package size is too large, return -1
     echo "Package size is too large"
     exit -1
 fi


### PR DESCRIPTION
**Issue:**
The release pipeline failed due to the package size creeping up over our self-imposed limit

**Description of changes:**
* Bump limit from 14MiB -> 15MB
* Add note to size-check we do in CI, reminding users that there's also a release-time check.
  * It sucks these checks aren't the same, but it would be a lot of work to check the TOTAL size in CI, which is an accumulation of every supported platform


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
