### PR TITLE
Rework Mqtt5 Websocket Connection Integration Test

### DIFF
--- a/lib/native/aws_iot_mqtt5.spec.ts
+++ b/lib/native/aws_iot_mqtt5.spec.ts
@@ -7,6 +7,7 @@ import * as test_utils from "@test/mqtt5";
 import * as mqtt5 from "./mqtt5";
 import * as iot from "./iot";
 import * as fs from 'fs';
+import * as auth from "../browser/auth";
 
 jest.setTimeout(10000);
 
@@ -69,13 +70,17 @@ test_utils.conditional_test(test_utils.ClientEnvironmentalConfig.hasIotCoreEnvir
 });
 
 // requires correct credentials to be sourced from the default credentials provider chain
-test_utils.conditional_test(test_utils.ClientEnvironmentalConfig.hasIotCoreEnvironment())('Aws Iot Core Websocket by default credentials provider - Connection Success', async () => {
+test_utils.conditional_test(test_utils.ClientEnvironmentalConfig.hasIotCoreEnvironment())('Aws Iot Core Websocket by environment credentials - Connection Success', async () => {
+
+    let provider: auth.StaticCredentialProvider = new auth.StaticCredentialProvider({
+        aws_access_id: test_utils.ClientEnvironmentalConfig.AWS_IOT_ACCESS_KEY_ID,
+        aws_secret_key: test_utils.ClientEnvironmentalConfig.AWS_IOT_SECRET_ACCESS_KEY,
+        aws_region: "us-east-1"
+    });
 
     let builder = iot.AwsIotMqtt5ClientConfigBuilder.newWebsocketMqttBuilderWithSigv4Auth(
         test_utils.ClientEnvironmentalConfig.AWS_IOT_HOST,
-        // the region extraction logic does not work for gamma endpoint formats so pass in region manually
-        // TODO: remove this when we switch to live target
-        { region: "us-east-1" }
+        { credentialsProvider: provider }
     );
 
     await test_utils.testConnect(new mqtt5.Mqtt5Client(builder.build()));


### PR DESCRIPTION
Use credentials from secrets rather than the default provider.  The default provider will pick up CI-injected credentials which may not have enough permissions to successfully run the test.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
