### PR TITLE
Mqtt311 operation statistics support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Normally, you just declare `aws-crt` as a dependency in your package.json file.
 You can either add it to package.json (if using a tool like webpack), or just import the ```dist.browser/``` folder into your web project
 
 ### Installing from npm
+
 ```bash
 npm install aws-crt
 ```

--- a/lib/native/binding.d.ts
+++ b/lib/native/binding.d.ts
@@ -17,6 +17,7 @@ import { OnMessageCallback, QoS } from "../common/mqtt";
 import { Mqtt5ClientConfig, Mqtt5Client, ClientStatistics, NegotiatedSettings } from "./mqtt5";
 import * as mqtt5_packet from "../common/mqtt5_packet";
 import { PublishCompletionResult } from "../common/mqtt5";
+import { ConnectionStatistics } from "./mqtt";
 
 
 /**
@@ -256,6 +257,9 @@ export function mqtt_client_connection_disconnect(connection: NativeHandle, on_d
 
 /** @internal */
 export function mqtt_client_connection_close(connection: NativeHandle): void;
+
+/** @internal */
+export function mqtt_client_connection_get_queue_statistics(connection: NativeHandle): ConnectionStatistics;
 
 /* HTTP */
 /* wraps aws_http_proxy_options #TODO: Wrap with ClassBinder */

--- a/lib/native/binding.d.ts
+++ b/lib/native/binding.d.ts
@@ -259,7 +259,7 @@ export function mqtt_client_connection_disconnect(connection: NativeHandle, on_d
 export function mqtt_client_connection_close(connection: NativeHandle): void;
 
 /** @internal */
-export function mqtt_client_connection_get_queue_statistics(connection: NativeHandle): ConnectionStatistics;
+export function mqtt_client_connection_get_queue_statistics(connection: NativeHandle) : ConnectionStatistics;
 
 /* HTTP */
 /* wraps aws_http_proxy_options #TODO: Wrap with ClassBinder */

--- a/lib/native/mqtt.spec.ts
+++ b/lib/native/mqtt.spec.ts
@@ -161,10 +161,7 @@ test('MQTT Operation statistics simple', async () => {
             const test_topic = `/test/me/senpai/${uuid()}`;
             const test_payload = 'NOTICE ME';
 
-            // const pub = connection.publish(test_topic, test_payload, QoS.AtLeastOnce);
-            // await expect(pub).resolves.toBeTruthy();
-            connection.publish(test_topic, test_payload, QoS.AtLeastOnce);
-            await setTimeout(()=>{}, 2000);
+            await connection.publish(test_topic, test_payload, QoS.AtLeastOnce);
 
             statistics = connection.getQueueStatistics();
             expect(statistics.incompleteOperationCount).toBeLessThanOrEqual(0);
@@ -210,8 +207,7 @@ test('MQTT Operation statistics check publish', async () => {
             // Per packet: (The size of the topic, the size of the payload, 2 for the header and 2 for the packet ID)
             const expected_packet_size = test_topic.length + test_payload.length + 4;
 
-            // const pub = connection.publish(test_topic, test_payload, QoS.AtLeastOnce);
-            connection.publish(test_topic, test_payload, QoS.AtLeastOnce);
+            const pub = connection.publish(test_topic, test_payload, QoS.AtLeastOnce);
 
             let statistics = connection.getQueueStatistics();
             expect(statistics.incompleteOperationCount).toBeGreaterThanOrEqual(1);
@@ -219,12 +215,11 @@ test('MQTT Operation statistics check publish', async () => {
             expect(statistics.unackedOperationCount).toBeLessThanOrEqual(0);
             expect(statistics.unackedOperationSize).toBeLessThanOrEqual(0);
 
-            // await expect(pub).resolves.toBeTruthy();
-            await setTimeout(()=>{}, 2000);
+            await pub;
 
             statistics = connection.getQueueStatistics();
-            expect(statistics.incompleteOperationCount).toBeGreaterThanOrEqual(0);
-            expect(statistics.incompleteOperationSize).toBeGreaterThanOrEqual(0);
+            expect(statistics.incompleteOperationCount).toBeLessThanOrEqual(0);
+            expect(statistics.incompleteOperationSize).toBeLessThanOrEqual(0);
             expect(statistics.unackedOperationCount).toBeLessThanOrEqual(0);
             expect(statistics.unackedOperationSize).toBeLessThanOrEqual(0);
         });

--- a/lib/native/mqtt.spec.ts
+++ b/lib/native/mqtt.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { ClientBootstrap, Pkcs11Lib, TlsContextOptions } from '@awscrt/io';
-import { MqttClient } from '@awscrt/mqtt';
+import { MqttClient, QoS, Payload } from '@awscrt/mqtt';
 import { AwsIotMqttConnectionConfigBuilder, WebsocketConfig } from '@awscrt/aws_iot';
 import { AwsCredentialsProvider } from '@awscrt/auth';
 import { Config, fetch_credentials } from '@test/credentials';
@@ -127,4 +127,108 @@ test('MQTT Native ECC key Connect/Disconnect', async () => {
     const builder = AwsIotMqttConnectionConfigBuilder.new_mtls_builder(aws_opts.ecc_certificate, aws_opts.ecc_private_key);
 
     await test_builder(aws_opts, builder, new MqttClient(new ClientBootstrap()));
+});
+
+test('MQTT Operation statistics simple', async () => {
+    const promise = new Promise(async (resolve, reject) => {
+        let aws_opts: Config;
+        try {
+            aws_opts = await fetch_credentials();
+        } catch (err) {
+            reject(err);
+            return;
+        }
+
+        const config = AwsIotMqttConnectionConfigBuilder.new_mtls_builder(aws_opts.certificate, aws_opts.private_key)
+            .with_clean_session(true)
+            .with_client_id(`node-mqtt-unit-test-${uuid()}`)
+            .with_endpoint(aws_opts.endpoint)
+            .with_credentials(Config.region, aws_opts.access_key, aws_opts.secret_key, aws_opts.session_token)
+            .with_ping_timeout_ms(5000)
+            .build()
+        const client = new MqttClient(new ClientBootstrap());
+        const connection = client.new_connection(config);
+
+        connection.on('connect', async (session_present) => {
+            expect(session_present).toBeFalsy();
+
+            let statistics = connection.getQueueStatistics();
+            expect(statistics.incompleteOperationCount).toBeLessThanOrEqual(0);
+            expect(statistics.incompleteOperationSize).toBeLessThanOrEqual(0);
+            expect(statistics.unackedOperationCount).toBeLessThanOrEqual(0);
+            expect(statistics.unackedOperationSize).toBeLessThanOrEqual(0);
+
+            const test_topic = `/test/me/senpai/${uuid()}`;
+            const test_payload = 'NOTICE ME';
+
+            const pub = connection.publish(test_topic, test_payload, QoS.AtLeastOnce);
+            await expect(pub).resolves.toBeTruthy();
+
+            statistics = connection.getQueueStatistics();
+            expect(statistics.incompleteOperationCount).toBeLessThanOrEqual(0);
+            expect(statistics.incompleteOperationSize).toBeLessThanOrEqual(0);
+            expect(statistics.unackedOperationCount).toBeLessThanOrEqual(0);
+            expect(statistics.unackedOperationSize).toBeLessThanOrEqual(0);
+
+        });
+        connection.on('error', (error) => {
+            reject(error);
+        })
+        const connected = connection.connect();
+        await expect(connected).resolves.toBeDefined();
+    });
+    await expect(promise).resolves.toBeTruthy();
+});
+
+test('MQTT Operation statistics check publish', async () => {
+    const promise = new Promise(async (resolve, reject) => {
+        let aws_opts: Config;
+        try {
+            aws_opts = await fetch_credentials();
+        } catch (err) {
+            reject(err);
+            return;
+        }
+
+        const config = AwsIotMqttConnectionConfigBuilder.new_mtls_builder(aws_opts.certificate, aws_opts.private_key)
+            .with_clean_session(true)
+            .with_client_id(`node-mqtt-unit-test-${uuid()}`)
+            .with_endpoint(aws_opts.endpoint)
+            .with_credentials(Config.region, aws_opts.access_key, aws_opts.secret_key, aws_opts.session_token)
+            .with_ping_timeout_ms(5000)
+            .build()
+        const client = new MqttClient(new ClientBootstrap());
+        const connection = client.new_connection(config);
+
+        connection.on('connect', async (session_present) => {
+            expect(session_present).toBeFalsy();
+
+            const test_topic = `/test/me/senpai/${uuid()}`;
+            const test_payload = 'NOTICE ME';
+            // Per packet: (The size of the topic, the size of the payload, 2 for the header and 2 for the packet ID)
+            const expected_packet_size = test_topic.length + test_payload.length + 4;
+
+            const pub = connection.publish(test_topic, test_payload, QoS.AtLeastOnce);
+
+            let statistics = connection.getQueueStatistics();
+            expect(statistics.incompleteOperationCount).toBeGreaterThanOrEqual(1);
+            expect(statistics.incompleteOperationSize).toBeGreaterThanOrEqual(expected_packet_size);
+            expect(statistics.unackedOperationCount).toBeLessThanOrEqual(0);
+            expect(statistics.unackedOperationSize).toBeLessThanOrEqual(0);
+
+            await expect(pub).resolves.toBeTruthy();
+
+            statistics = connection.getQueueStatistics();
+            expect(statistics.incompleteOperationCount).toBeGreaterThanOrEqual(0);
+            expect(statistics.incompleteOperationSize).toBeGreaterThanOrEqual(0);
+            expect(statistics.unackedOperationCount).toBeLessThanOrEqual(0);
+            expect(statistics.unackedOperationSize).toBeLessThanOrEqual(0);
+        });
+        connection.on('error', (error) => {
+            reject(error);
+        })
+        const connected = connection.connect();
+        await expect(connected).resolves.toBeDefined();
+    });
+    await expect(promise).resolves.toBeTruthy();
 });

--- a/lib/native/mqtt.spec.ts
+++ b/lib/native/mqtt.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { ClientBootstrap, Pkcs11Lib, TlsContextOptions } from '@awscrt/io';
-import { MqttClient, QoS, Payload } from '@awscrt/mqtt';
+import { MqttClient, QoS } from '@awscrt/mqtt';
 import { AwsIotMqttConnectionConfigBuilder, WebsocketConfig } from '@awscrt/aws_iot';
 import { AwsCredentialsProvider } from '@awscrt/auth';
 import { Config, fetch_credentials } from '@test/credentials';

--- a/lib/native/mqtt.spec.ts
+++ b/lib/native/mqtt.spec.ts
@@ -161,8 +161,10 @@ test('MQTT Operation statistics simple', async () => {
             const test_topic = `/test/me/senpai/${uuid()}`;
             const test_payload = 'NOTICE ME';
 
-            const pub = connection.publish(test_topic, test_payload, QoS.AtLeastOnce);
-            await expect(pub).resolves.toBeTruthy();
+            // const pub = connection.publish(test_topic, test_payload, QoS.AtLeastOnce);
+            // await expect(pub).resolves.toBeTruthy();
+            connection.publish(test_topic, test_payload, QoS.AtLeastOnce);
+            await setTimeout(()=>{}, 2000);
 
             statistics = connection.getQueueStatistics();
             expect(statistics.incompleteOperationCount).toBeLessThanOrEqual(0);
@@ -208,7 +210,8 @@ test('MQTT Operation statistics check publish', async () => {
             // Per packet: (The size of the topic, the size of the payload, 2 for the header and 2 for the packet ID)
             const expected_packet_size = test_topic.length + test_payload.length + 4;
 
-            const pub = connection.publish(test_topic, test_payload, QoS.AtLeastOnce);
+            // const pub = connection.publish(test_topic, test_payload, QoS.AtLeastOnce);
+            connection.publish(test_topic, test_payload, QoS.AtLeastOnce);
 
             let statistics = connection.getQueueStatistics();
             expect(statistics.incompleteOperationCount).toBeGreaterThanOrEqual(1);
@@ -216,7 +219,8 @@ test('MQTT Operation statistics check publish', async () => {
             expect(statistics.unackedOperationCount).toBeLessThanOrEqual(0);
             expect(statistics.unackedOperationSize).toBeLessThanOrEqual(0);
 
-            await expect(pub).resolves.toBeTruthy();
+            // await expect(pub).resolves.toBeTruthy();
+            await setTimeout(()=>{}, 2000);
 
             statistics = connection.getQueueStatistics();
             expect(statistics.incompleteOperationCount).toBeGreaterThanOrEqual(0);

--- a/lib/native/mqtt.ts
+++ b/lib/native/mqtt.ts
@@ -185,6 +185,36 @@ export interface MqttConnectionConfig {
 }
 
 /**
+ * Information about the connection's queue of operations
+ */
+ export interface ConnectionStatistics {
+
+    /**
+     * Total number of operations submitted to the connection that have not yet been completed.  Unacked operations
+     * are a subset of this.
+     */
+    incompleteOperationCount : number;
+
+    /**
+     * Total packet size of operations submitted to the connection that have not yet been completed.  Unacked operations
+     * are a subset of this.
+     */
+    incompleteOperationSize : number;
+
+    /**
+     * Total number of operations that have been sent to the server and are waiting for a corresponding ACK before
+     * they can be completed.
+     */
+    unackedOperationCount : number;
+
+    /**
+     * Total packet size of operations that have been sent to the server and are waiting for a corresponding ACK before
+     * they can be completed.
+     */
+    unackedOperationSize : number;
+};
+
+/**
  * MQTT client connection
  *
  * @category MQTT
@@ -462,6 +492,15 @@ export class MqttClientConnection extends NativeResourceMixin(BufferedEventEmitt
                 reject(e);
             }
         });
+    }
+
+    /**
+     * Queries a small set of numerical statistics about the current state of the connection's operation queue
+     *
+     * @group Node-only
+     */
+     getQueueStatistics() : ConnectionStatistics {
+        return crt_native.mqtt_client_connection_get_queue_statistics(this.native_handle());
     }
 
     // Wrap a promise rejection with a function that will also emit the error as an event

--- a/source/module.c
+++ b/source/module.c
@@ -1077,6 +1077,7 @@ static bool s_module_initialized = false;
     CREATE_AND_REGISTER_FN(mqtt_client_connection_unsubscribe)
     CREATE_AND_REGISTER_FN(mqtt_client_connection_disconnect)
     CREATE_AND_REGISTER_FN(mqtt_client_connection_close)
+    CREATE_AND_REGISTER_FN(mqtt_client_connection_get_queue_statistics)
 
     /* Crypto */
     CREATE_AND_REGISTER_FN(hash_md5_new)

--- a/source/mqtt_client_connection.c
+++ b/source/mqtt_client_connection.c
@@ -19,6 +19,11 @@
 #include <aws/common/linked_list.h>
 #include <aws/common/mutex.h>
 
+static const char *AWS_NAPI_KEY_INCOMPLETE_OPERATION_COUNT = "incompleteOperationCount";
+static const char *AWS_NAPI_KEY_INCOMPLETE_OPERATION_SIZE = "incompleteOperationSize";
+static const char *AWS_NAPI_KEY_UNACKED_OPERATION_COUNT = "unackedOperationCount";
+static const char *AWS_NAPI_KEY_UNACKED_OPERATION_SIZE = "unackedOperationSize";
+
 static void s_transform_websocket_call(napi_env env, napi_value transform_websocket, void *context, void *user_data);
 void s_transform_websocket(
     struct aws_http_message *request,
@@ -1821,20 +1826,20 @@ static int s_create_napi_mqtt_connection_statistics(
         env, napi_create_object(env, &napi_stats), { return aws_raise_error(AWS_CRT_NODEJS_ERROR_NAPI_FAILURE); });
 
     if (aws_napi_attach_object_property_u64(
-            napi_stats, env, "incompleteOperationCount", stats->incomplete_operation_count)) {
+            napi_stats, env, AWS_NAPI_KEY_INCOMPLETE_OPERATION_COUNT, stats->incomplete_operation_count)) {
         return AWS_OP_ERR;
     }
 
     if (aws_napi_attach_object_property_u64(
-            napi_stats, env, "incompleteOperationSize", stats->incomplete_operation_size)) {
+            napi_stats, env, AWS_NAPI_KEY_INCOMPLETE_OPERATION_SIZE, stats->incomplete_operation_size)) {
         return AWS_OP_ERR;
     }
 
-    if (aws_napi_attach_object_property_u64(napi_stats, env, "unackedOperationCount", stats->unacked_operation_count)) {
+    if (aws_napi_attach_object_property_u64(napi_stats, env, AWS_NAPI_KEY_UNACKED_OPERATION_COUNT, stats->unacked_operation_count)) {
         return AWS_OP_ERR;
     }
 
-    if (aws_napi_attach_object_property_u64(napi_stats, env, "unackedOperationSize", stats->unacked_operation_size)) {
+    if (aws_napi_attach_object_property_u64(napi_stats, env, AWS_NAPI_KEY_UNACKED_OPERATION_SIZE, stats->unacked_operation_size)) {
         return AWS_OP_ERR;
     };
 

--- a/source/mqtt_client_connection.c
+++ b/source/mqtt_client_connection.c
@@ -1806,3 +1806,86 @@ on_error:
 
     return NULL;
 }
+
+static int s_create_napi_mqtt_connection_statistics(
+    napi_env env,
+    const struct aws_mqtt_connection_operation_statistics *stats,
+    napi_value *stats_out) {
+
+    if (env == NULL) {
+        return aws_raise_error(AWS_CRT_NODEJS_ERROR_THREADSAFE_FUNCTION_NULL_NAPI_ENV);
+    }
+
+    napi_value napi_stats = NULL;
+    AWS_NAPI_CALL(
+        env, napi_create_object(env, &napi_stats), { return aws_raise_error(AWS_CRT_NODEJS_ERROR_NAPI_FAILURE); });
+
+    if (aws_napi_attach_object_property_u64(
+            napi_stats, env, AWS_NAPI_KEY_INCOMPLETE_OPERATION_COUNT, stats->incomplete_operation_count)) {
+        return AWS_OP_ERR;
+    }
+
+    if (aws_napi_attach_object_property_u64(
+            napi_stats, env, AWS_NAPI_KEY_INCOMPLETE_OPERATION_SIZE, stats->incomplete_operation_size)) {
+        return AWS_OP_ERR;
+    }
+
+    if (aws_napi_attach_object_property_u64(
+            napi_stats, env, AWS_NAPI_KEY_UNACKED_OPERATION_COUNT, stats->unacked_operation_count)) {
+        return AWS_OP_ERR;
+    }
+
+    if (aws_napi_attach_object_property_u64(
+            napi_stats, env, AWS_NAPI_KEY_UNACKED_OPERATION_SIZE, stats->unacked_operation_size)) {
+        return AWS_OP_ERR;
+    };
+
+    *stats_out = napi_stats;
+
+    return AWS_OP_SUCCESS;
+}
+
+napi_value aws_napi_mqtt_connection_get_queue_statistics(napi_env env, napi_callback_info info) {
+
+    napi_value node_args[1];
+    size_t num_args = AWS_ARRAY_SIZE(node_args);
+    napi_value *arg = &node_args[0];
+    AWS_NAPI_CALL(env, napi_get_cb_info(env, info, &num_args, node_args, NULL, NULL), {
+        napi_throw_error(env, NULL, "aws_napi_mqtt_connection_get_queue_statistics - Failed to extract parameter array");
+        return NULL;
+    });
+
+    if (num_args != AWS_ARRAY_SIZE(node_args)) {
+        napi_throw_error(env, NULL, "aws_napi_mqtt_connection_get_queue_statistics - needs exactly 1 argument");
+        return NULL;
+    }
+
+    struct mqtt_connection_binding *binding = NULL;
+    napi_value node_binding = *arg++;
+    AWS_NAPI_CALL(env, napi_get_value_external(env, node_binding, (void **)&binding), {
+        napi_throw_error(env, NULL, "Failed to extract binding from external");
+        return NULL;
+    });
+
+    if (binding == NULL) {
+        napi_throw_error(env, NULL, "aws_napi_mqtt_connection_get_queue_statistics - binding was null");
+        return NULL;
+    }
+
+    if (binding->connection == NULL) {
+        napi_throw_error(env, NULL, "aws_napi_mqtt_connection_get_queue_statistics - connection was null");
+        return NULL;
+    }
+
+    struct aws_mqtt_connection_operation_statistics stats;
+    AWS_ZERO_STRUCT(stats);
+    aws_mqtt_client_connection_get_stats(binding->connection, &stats);
+
+    napi_value napi_stats = NULL;
+    if (s_create_napi_mqtt_connection_statistics(env, &stats, &napi_stats)) {
+        napi_throw_error(env, NULL, "aws_napi_mqtt_connection_get_queue_statistics - failed to build statistics value");
+        return NULL;
+    }
+
+    return napi_stats;
+}

--- a/source/mqtt_client_connection.c
+++ b/source/mqtt_client_connection.c
@@ -1821,22 +1821,20 @@ static int s_create_napi_mqtt_connection_statistics(
         env, napi_create_object(env, &napi_stats), { return aws_raise_error(AWS_CRT_NODEJS_ERROR_NAPI_FAILURE); });
 
     if (aws_napi_attach_object_property_u64(
-            napi_stats, env, AWS_NAPI_KEY_INCOMPLETE_OPERATION_COUNT, stats->incomplete_operation_count)) {
+            napi_stats, env, "incompleteOperationCount", stats->incomplete_operation_count)) {
         return AWS_OP_ERR;
     }
 
     if (aws_napi_attach_object_property_u64(
-            napi_stats, env, AWS_NAPI_KEY_INCOMPLETE_OPERATION_SIZE, stats->incomplete_operation_size)) {
+            napi_stats, env, "incompleteOperationSize", stats->incomplete_operation_size)) {
         return AWS_OP_ERR;
     }
 
-    if (aws_napi_attach_object_property_u64(
-            napi_stats, env, AWS_NAPI_KEY_UNACKED_OPERATION_COUNT, stats->unacked_operation_count)) {
+    if (aws_napi_attach_object_property_u64(napi_stats, env, "unackedOperationCount", stats->unacked_operation_count)) {
         return AWS_OP_ERR;
     }
 
-    if (aws_napi_attach_object_property_u64(
-            napi_stats, env, AWS_NAPI_KEY_UNACKED_OPERATION_SIZE, stats->unacked_operation_size)) {
+    if (aws_napi_attach_object_property_u64(napi_stats, env, "unackedOperationSize", stats->unacked_operation_size)) {
         return AWS_OP_ERR;
     };
 
@@ -1845,18 +1843,19 @@ static int s_create_napi_mqtt_connection_statistics(
     return AWS_OP_SUCCESS;
 }
 
-napi_value aws_napi_mqtt_connection_get_queue_statistics(napi_env env, napi_callback_info info) {
+napi_value aws_napi_mqtt_client_connection_get_queue_statistics(napi_env env, napi_callback_info info) {
 
     napi_value node_args[1];
     size_t num_args = AWS_ARRAY_SIZE(node_args);
     napi_value *arg = &node_args[0];
     AWS_NAPI_CALL(env, napi_get_cb_info(env, info, &num_args, node_args, NULL, NULL), {
-        napi_throw_error(env, NULL, "aws_napi_mqtt_connection_get_queue_statistics - Failed to extract parameter array");
+        napi_throw_error(
+            env, NULL, "aws_napi_mqtt_client_connection_get_queue_statistics - Failed to extract parameter array");
         return NULL;
     });
 
     if (num_args != AWS_ARRAY_SIZE(node_args)) {
-        napi_throw_error(env, NULL, "aws_napi_mqtt_connection_get_queue_statistics - needs exactly 1 argument");
+        napi_throw_error(env, NULL, "aws_napi_mqtt_client_connection_get_queue_statistics - needs exactly 1 argument");
         return NULL;
     }
 
@@ -1868,12 +1867,12 @@ napi_value aws_napi_mqtt_connection_get_queue_statistics(napi_env env, napi_call
     });
 
     if (binding == NULL) {
-        napi_throw_error(env, NULL, "aws_napi_mqtt_connection_get_queue_statistics - binding was null");
+        napi_throw_error(env, NULL, "aws_napi_mqtt_client_connection_get_queue_statistics - binding was null");
         return NULL;
     }
 
     if (binding->connection == NULL) {
-        napi_throw_error(env, NULL, "aws_napi_mqtt_connection_get_queue_statistics - connection was null");
+        napi_throw_error(env, NULL, "aws_napi_mqtt_client_connection_get_queue_statistics - connection was null");
         return NULL;
     }
 
@@ -1883,7 +1882,8 @@ napi_value aws_napi_mqtt_connection_get_queue_statistics(napi_env env, napi_call
 
     napi_value napi_stats = NULL;
     if (s_create_napi_mqtt_connection_statistics(env, &stats, &napi_stats)) {
-        napi_throw_error(env, NULL, "aws_napi_mqtt_connection_get_queue_statistics - failed to build statistics value");
+        napi_throw_error(
+            env, NULL, "aws_napi_mqtt_client_connection_get_queue_statistics - failed to build statistics value");
         return NULL;
     }
 

--- a/source/mqtt_client_connection.c
+++ b/source/mqtt_client_connection.c
@@ -1835,11 +1835,13 @@ static int s_create_napi_mqtt_connection_statistics(
         return AWS_OP_ERR;
     }
 
-    if (aws_napi_attach_object_property_u64(napi_stats, env, AWS_NAPI_KEY_UNACKED_OPERATION_COUNT, stats->unacked_operation_count)) {
+    if (aws_napi_attach_object_property_u64(
+            napi_stats, env, AWS_NAPI_KEY_UNACKED_OPERATION_COUNT, stats->unacked_operation_count)) {
         return AWS_OP_ERR;
     }
 
-    if (aws_napi_attach_object_property_u64(napi_stats, env, AWS_NAPI_KEY_UNACKED_OPERATION_SIZE, stats->unacked_operation_size)) {
+    if (aws_napi_attach_object_property_u64(
+            napi_stats, env, AWS_NAPI_KEY_UNACKED_OPERATION_SIZE, stats->unacked_operation_size)) {
         return AWS_OP_ERR;
     };
 

--- a/source/mqtt_client_connection.h
+++ b/source/mqtt_client_connection.h
@@ -16,5 +16,6 @@ napi_value aws_napi_mqtt_client_connection_subscribe(napi_env env, napi_callback
 napi_value aws_napi_mqtt_client_connection_on_message(napi_env env, napi_callback_info info);
 napi_value aws_napi_mqtt_client_connection_unsubscribe(napi_env env, napi_callback_info info);
 napi_value aws_napi_mqtt_client_connection_disconnect(napi_env env, napi_callback_info info);
+napi_value aws_napi_mqtt_connection_get_queue_statistics(napi_env env, napi_callback_info info);
 
 #endif /* AWS_CRT_NODEJS_MQTT_CLIENT_CONNECTION_H */

--- a/source/mqtt_client_connection.h
+++ b/source/mqtt_client_connection.h
@@ -16,6 +16,6 @@ napi_value aws_napi_mqtt_client_connection_subscribe(napi_env env, napi_callback
 napi_value aws_napi_mqtt_client_connection_on_message(napi_env env, napi_callback_info info);
 napi_value aws_napi_mqtt_client_connection_unsubscribe(napi_env env, napi_callback_info info);
 napi_value aws_napi_mqtt_client_connection_disconnect(napi_env env, napi_callback_info info);
-napi_value aws_napi_mqtt_connection_get_queue_statistics(napi_env env, napi_callback_info info);
+napi_value aws_napi_mqtt_client_connection_get_queue_statistics(napi_env env, napi_callback_info info);
 
 #endif /* AWS_CRT_NODEJS_MQTT_CLIENT_CONNECTION_H */


### PR DESCRIPTION
*Description of changes:*

Adds operation statistics support to `aws-crt-nodejs` for MQTT311. Also adds operation statistics support tests for both MQTT311 and MQTT5 to increase code coverage and safety.

~~Relies on https://github.com/awslabs/aws-c-mqtt/pull/247 being merged and released.~~

__________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.