### PR TITLE
More usefull errors when missing data

### DIFF
--- a/lib/browser/aws_iot.ts
+++ b/lib/browser/aws_iot.ts
@@ -201,19 +201,19 @@ export class AwsIotMqttConnectionConfigBuilder {
     }
 
     /**
-     * Configures Static AWS credentials for this connection. 
+     * Configures Static AWS credentials for this connection.
      * Please note that the static credential will fail when the web session expired.
      * @param aws_region The service region to connect to
      * @param aws_access_id IAM Access ID
      * @param aws_secret_key IAM Secret Key
      * @param aws_sts_token session credentials token (optional)
-     * 
+     *
      * @returns this builder object
      */
      with_credentials(aws_region: string, aws_access_id: string, aws_secret_key: string, aws_sts_token?: string) {
         const provider = new StaticCredentialProvider(
-            { aws_region: aws_region, 
-              aws_access_id: aws_access_id, 
+            { aws_region: aws_region,
+              aws_access_id: aws_access_id,
               aws_secret_key: aws_secret_key,
               aws_sts_token: aws_sts_token});
         this.params.credentials_provider = provider;
@@ -223,7 +223,7 @@ export class AwsIotMqttConnectionConfigBuilder {
     /**
      * Configures credentials provider (currently support for AWS Cognito Credential Provider) for this connection
      * @param customer_provider credential provider used to update credential when session expired (optional)
-     * 
+     *
      * @returns this builder object
      */
     with_credential_provider( customer_provider : CredentialsProvider) {
@@ -277,9 +277,9 @@ export class AwsIotMqttConnectionConfigBuilder {
     }
 
     /**
-     * Configure the max reconnection period (in second). The reonnection period will
-     * be set in range of [reconnect_min_sec,reconnect_max_sec]. 
-     * @param reconnect_max_sec max reconnection period 
+     * Configure the max reconnection period (in second). The reconnection period will
+     * be set in range of [reconnect_min_sec,reconnect_max_sec].
+     * @param reconnect_max_sec max reconnection period
      */
     with_reconnect_max_sec(max_sec: number) {
         this.params.reconnect_max_sec = max_sec;
@@ -287,9 +287,9 @@ export class AwsIotMqttConnectionConfigBuilder {
     }
 
     /**
-     * Configure the min reconnection period (in second). The reonnection period will
-     * be set in range of [reconnect_min_sec,reconnect_max_sec]. 
-     * @param reconnect_min_sec min reconnection period 
+     * Configure the min reconnection period (in second). The reconnection period will
+     * be set in range of [reconnect_min_sec,reconnect_max_sec].
+     * @param reconnect_min_sec min reconnection period
      */
     with_reconnect_min_sec(min_sec: number) {
         this.params.reconnect_min_sec = min_sec;

--- a/lib/browser/aws_iot_mqtt5.ts
+++ b/lib/browser/aws_iot_mqtt5.ts
@@ -13,6 +13,7 @@ import * as mqtt5 from "./mqtt5";
 import * as mqtt5_packet from "../common/mqtt5_packet";
 import * as auth from "./auth";
 import * as iot_shared from "../common/aws_iot_shared";
+import { CrtError } from "./error";
 
 export { MqttConnectCustomAuthConfig } from '../common/aws_iot_shared';
 
@@ -80,6 +81,10 @@ export class AwsIotMqtt5ClientConfigBuilder {
      * @param sigv4Config - additional sigv4-oriented options to use
      */
     static newWebsocketMqttBuilderWithSigv4Auth(hostName : string, sigv4Config: WebsocketSigv4Config) : AwsIotMqtt5ClientConfigBuilder {
+
+        if (sigv4Config == null || sigv4Config == undefined) {
+            throw new CrtError("AwsIotMqtt5ClientConfigBuilder newWebsocketMqttBuilderWithSigv4Auth: sigv4Config not defined");
+        }
 
         let region : string = sigv4Config.region ?? iot_shared.extractRegionFromEndpoint(hostName);
 

--- a/lib/browser/http.ts
+++ b/lib/browser/http.ts
@@ -106,7 +106,7 @@ export class HttpHeaders implements CommonHttpHeaders {
      * @param default_value - Value returned if no values are found for the given name
      * @return The first header value, or default if no values exist
      */
-    get(name: string, default_value = "") {
+    get(name: string, default_value: string = "") {
         const values = this.headers[name.toLowerCase()];
         if (!values) {
             return default_value;
@@ -325,6 +325,10 @@ export class HttpClientConnection extends BufferedEventEmitter {
 }
 
 function stream_request(connection: HttpClientConnection, request: HttpRequest) {
+    if (request == null || request == undefined) {
+        throw new CrtError("HttpClientConnection stream_request: request not defined");
+    }
+
     const _to_object = (headers: HttpHeaders) => {
         // browsers refuse to let users configure host or user-agent
         const forbidden_headers = ['host', 'user-agent'];

--- a/lib/browser/mqtt.ts
+++ b/lib/browser/mqtt.ts
@@ -95,7 +95,7 @@ export interface MqttConnectionConfig {
      * The `session_present` bool in the connection callback informs
      * whether an existing session was successfully resumed.
      * If an existing session is resumed, the server remembers previous subscriptions
-     * and sends mesages (with QoS1 or higher) that were published while the client was offline.
+     * and sends messages (with QoS1 or higher) that were published while the client was offline.
      */
     clean_session?: boolean;
 
@@ -157,7 +157,7 @@ export interface MqttConnectionConfig {
     /** AWS credentials, which will be used to sign the websocket request */
     credentials?: AWSCredentials;
 
-    /** Options for the underlying credentianls provider */
+    /** Options for the underlying credentials provider */
     credentials_provider?: auth.CredentialsProvider;
 }
 
@@ -259,6 +259,10 @@ export class MqttClientConnection extends BufferedEventEmitter {
 
         const create_websocket_stream = (client: mqtt.MqttClient) => WebsocketUtils.create_websocket_stream(this.config);
         const transform_websocket_url = (url: string, options: mqtt.IClientOptions, client: mqtt.MqttClient) => WebsocketUtils.create_websocket_url(this.config);
+
+        if (config == null || config == undefined) {
+            throw new CrtError("MqttClientConnection constructor: config not defined");
+        }
 
         const will = this.config.will ? {
             topic: this.config.will.topic,
@@ -480,7 +484,7 @@ export class MqttClientConnection extends BufferedEventEmitter {
      * Unsubscribe from a topic filter (async).
      * The client sends an UNSUBSCRIBE packet, and the server responds with an UNSUBACK.
      * @param topic The topic filter to unsubscribe from. May contain wildcards.
-     * @returns Promise wihch returns a {@link MqttRequest} which will contain the packet id
+     * @returns Promise which returns a {@link MqttRequest} which will contain the packet id
      *          of the UNSUBSCRIBE packet being acknowledged. Promise is resolved when an
      *          UNSUBACK is received from the server or is rejected when an exception occurs.
      */

--- a/lib/browser/mqtt5_utils.ts
+++ b/lib/browser/mqtt5_utils.ts
@@ -30,6 +30,10 @@ function set_defined_property(object: any, propertyName: string, value: any) : b
 
 /** @internal */
 export function transform_mqtt_js_connack_to_crt_connack(mqtt_js_connack: mqtt.IConnackPacket) : mqtt5.ConnackPacket {
+    if (mqtt_js_connack == null || mqtt_js_connack == undefined) {
+        throw new CrtError("transform_mqtt_js_connack_to_crt_connack: mqtt_js_connack not defined");
+    }
+
     let connack : mqtt5.ConnackPacket =  {
         type: mqtt5.PacketType.Connack,
         sessionPresent: mqtt_js_connack.sessionPresent,
@@ -57,6 +61,13 @@ export function transform_mqtt_js_connack_to_crt_connack(mqtt_js_connack: mqtt.I
 
 /** @internal */
 export function create_negotiated_settings(config : mqtt5.Mqtt5ClientConfig, connack: mqtt5.ConnackPacket) : mqtt5.NegotiatedSettings {
+    if (config == null || config == undefined) {
+        throw new CrtError("create_negotiated_settings: config not defined");
+    }
+    if (connack == null || connack == undefined) {
+        throw new CrtError("create_negotiated_settings: connack not defined");
+    }
+
     return {
         maximumQos: Math.min(connack.maximumQos ?? mqtt5.QoS.ExactlyOnce, mqtt5.QoS.AtLeastOnce),
         sessionExpiryInterval: connack.sessionExpiryInterval ?? config.connectProperties?.sessionExpiryIntervalSeconds ?? 0,
@@ -74,6 +85,10 @@ export function create_negotiated_settings(config : mqtt5.Mqtt5ClientConfig, con
 
 /** @internal */
 function create_mqtt_js_will_from_crt_config(connectProperties? : mqtt5.ConnectPacket) : any {
+    if (connectProperties == null || connectProperties == undefined) {
+        throw new CrtError("create_mqtt_js_will_from_crt_config: connectProperties not defined");
+    }
+
     if (!connectProperties || !connectProperties.will) {
         return undefined;
     }
@@ -168,6 +183,9 @@ function validate_optional_nonnegative_uint32(propertyName : string, value?: num
 }
 
 function validate_mqtt5_client_config(crtConfig : mqtt5.Mqtt5ClientConfig) {
+    if (crtConfig == null || crtConfig == undefined) {
+        throw new CrtError("validate_mqtt5_client_config: crtConfig not defined");
+    }
     validate_required_uint16("keepAliveIntervalSeconds", crtConfig.connectProperties?.keepAliveIntervalSeconds ?? 0);
     validate_optional_uint32("sessionExpiryIntervalSeconds", crtConfig.connectProperties?.sessionExpiryIntervalSeconds);
     validate_optional_uint16("receiveMaximum", crtConfig.connectProperties?.receiveMaximum);
@@ -272,6 +290,9 @@ export function transform_mqtt_js_user_properties_to_crt_user_properties(userPro
 }
 
 function validate_crt_disconnect(disconnect: mqtt5.DisconnectPacket) {
+    if (disconnect == null || disconnect == undefined) {
+        throw new CrtError("validate_crt_disconnect: disconnect not defined");
+    }
     validate_optional_uint32("sessionExpiryIntervalSeconds", disconnect.sessionExpiryIntervalSeconds);
 }
 
@@ -303,6 +324,10 @@ export function transform_crt_disconnect_to_mqtt_js_disconnect(disconnect: mqtt5
 /** @internal **/
 export function transform_mqtt_js_disconnect_to_crt_disconnect(disconnect: mqtt.IDisconnectPacket) : mqtt5.DisconnectPacket {
 
+    if (disconnect == null || disconnect == undefined) {
+        throw new CrtError("transform_mqtt_js_disconnect_to_crt_disconnect: disconnect not defined");
+    }
+
     let crtDisconnect : mqtt5.DisconnectPacket = {
         type: mqtt5.PacketType.Disconnect,
         reasonCode : disconnect.reasonCode ?? mqtt5.DisconnectReasonCode.NormalDisconnection
@@ -317,6 +342,9 @@ export function transform_mqtt_js_disconnect_to_crt_disconnect(disconnect: mqtt.
 }
 
 function validate_crt_subscribe(subscribe: mqtt5.SubscribePacket) {
+    if (subscribe == null || subscribe == undefined) {
+        throw new CrtError("validate_crt_subscribe: subscribe not defined");
+    }
     validate_optional_uint32("subscriptionIdentifier", subscribe.subscriptionIdentifier);
 }
 
@@ -347,6 +375,10 @@ export function transform_crt_subscribe_to_mqtt_js_subscribe_options(subscribe: 
     let properties = {};
     let propertiesValid : boolean = false;
 
+    if (subscribe == null || subscribe == undefined) {
+        throw new CrtError("transform_crt_subscribe_to_mqtt_js_subscribe_options: subscribe not defined");
+    }
+
     propertiesValid = set_defined_property(properties, "subscriptionIdentifier", subscribe.subscriptionIdentifier) || propertiesValid;
     propertiesValid = set_defined_property(properties, "userProperties", transform_crt_user_properties_to_mqtt_js_user_properties(subscribe.userProperties)) || propertiesValid;
 
@@ -363,6 +395,10 @@ export function transform_crt_subscribe_to_mqtt_js_subscribe_options(subscribe: 
 
 /** @internal **/
 export function transform_mqtt_js_subscription_grants_to_crt_suback(subscriptionsGranted: mqtt.ISubscriptionGrant[]) : mqtt5.SubackPacket {
+
+    if (subscriptionsGranted == null || subscriptionsGranted == undefined) {
+        throw new CrtError("transform_mqtt_js_subscription_grants_to_crt_suback: subscriptionsGranted not defined");
+    }
 
     let crtSuback : mqtt5.SubackPacket = {
         type: mqtt5.PacketType.Suback,
@@ -381,6 +417,9 @@ export function transform_mqtt_js_subscription_grants_to_crt_suback(subscription
 }
 
 function validate_crt_publish(publish: mqtt5.PublishPacket) {
+    if (publish == null || publish == undefined) {
+        throw new CrtError("validate_crt_publish: publish not defined");
+    }
     validate_optional_uint32("messageExpiryIntervalSeconds", publish.messageExpiryIntervalSeconds);
 }
 
@@ -415,6 +454,10 @@ export function transform_crt_publish_to_mqtt_js_publish_options(publish: mqtt5.
 
 /** @internal **/
 export function transform_mqtt_js_publish_to_crt_publish(publish: mqtt.IPublishPacket) : mqtt5.PublishPacket {
+
+    if (publish == null || publish == undefined) {
+        throw new CrtError("transform_mqtt_js_publish_to_crt_publish: publish not defined");
+    }
 
     let crtPublish : mqtt5.PublishPacket = {
         type: mqtt5.PacketType.Publish,
@@ -451,6 +494,10 @@ export function transform_mqtt_js_publish_to_crt_publish(publish: mqtt.IPublishP
 /** @internal **/
 export function transform_mqtt_js_puback_to_crt_puback(puback: mqtt.IPubackPacket) : mqtt5.PubackPacket {
 
+    if (puback == null || puback == undefined) {
+        throw new CrtError("transform_mqtt_js_puback_to_crt_puback: puback not defined");
+    }
+
     let crtPuback : mqtt5.PubackPacket = {
         type: mqtt5.PacketType.Puback,
         reasonCode: puback.reasonCode ?? mqtt5.PubackReasonCode.Success,
@@ -466,6 +513,10 @@ export function transform_mqtt_js_puback_to_crt_puback(puback: mqtt.IPubackPacke
 
 /** @internal **/
 export function transform_crt_unsubscribe_to_mqtt_js_unsubscribe_options(unsubscribe: mqtt5.UnsubscribePacket) : Object {
+
+    if (unsubscribe == null || unsubscribe == undefined) {
+        throw new CrtError("transform_crt_unsubscribe_to_mqtt_js_unsubscribe_options: unsubscribe not defined");
+    }
 
     let properties = {};
     let propertiesValid : boolean = false;
@@ -483,6 +534,10 @@ export function transform_crt_unsubscribe_to_mqtt_js_unsubscribe_options(unsubsc
 
 /** @internal **/
 export function transform_mqtt_js_unsuback_to_crt_unsuback(packet: mqtt.IUnsubackPacket) : mqtt5.UnsubackPacket {
+
+    if (packet == null || packet == undefined) {
+        throw new CrtError("transform_mqtt_js_unsuback_to_crt_unsuback: packet not defined");
+    }
 
     let reasonCodes : number | number[] | undefined = packet.reasonCode;
 

--- a/lib/browser/mqtt5_utils.ts
+++ b/lib/browser/mqtt5_utils.ts
@@ -85,10 +85,6 @@ export function create_negotiated_settings(config : mqtt5.Mqtt5ClientConfig, con
 
 /** @internal */
 function create_mqtt_js_will_from_crt_config(connectProperties? : mqtt5.ConnectPacket) : any {
-    if (connectProperties == null || connectProperties == undefined) {
-        throw new CrtError("create_mqtt_js_will_from_crt_config: connectProperties not defined");
-    }
-
     if (!connectProperties || !connectProperties.will) {
         return undefined;
     }

--- a/lib/browser/ws.ts
+++ b/lib/browser/ws.ts
@@ -51,6 +51,9 @@ function canonical_day(time: string = canonical_time()) {
 
 /** @internal */
 function make_signing_key(credentials: AWSCredentials, day: string, service_name: string) {
+    if (credentials == null || credentials == undefined) {
+        throw new CrtError("make_signing_key: credentials not defined");
+    }
     const hash_opts = { asBytes: true };
     let hash = Crypto.HmacSHA256(day, 'AWS4' + credentials.aws_secret_key, hash_opts);
     hash = Crypto.HmacSHA256(credentials.aws_region || '', hash, hash_opts);
@@ -66,6 +69,10 @@ function sign_url(method: string,
     time: string = canonical_time(),
     day: string = canonical_day(time),
     payload: string = '') {
+
+    if (signing_config == null || signing_config == undefined) {
+        throw new CrtError("sign_url: signing_config not defined");
+    }
 
     // region should not have been put in credentials, but we have to live with it
     let region: string = signing_config.credentials.aws_region ?? signing_config.region;
@@ -90,6 +97,9 @@ function sign_url(method: string,
 
 /** @internal */
 export function create_websocket_url(config: MqttConnectionConfig) {
+    if (config == null || config == undefined) {
+        throw new CrtError("create_websocket_url: config not defined");
+    }
     const path = '/mqtt';
     const protocol = (config.websocket || {}).protocol || 'wss';
     if (protocol === 'wss') {
@@ -124,6 +134,9 @@ export function create_websocket_stream(config: MqttConnectionConfig) {
 
 /** @internal */
 export function create_mqtt5_websocket_url(config: mqtt5.Mqtt5ClientConfig) {
+    if (config == null || config == undefined) {
+        throw new CrtError("create_mqtt5_websocket_url: config not defined");
+    }
     const path = '/mqtt';
     const websocketConfig : mqtt5.Mqtt5WebsocketConfig = config.websocketOptions ?? { urlFactoryOptions: { urlFactory: mqtt5.Mqtt5WebsocketUrlFactoryType.Ws} };
     const urlFactory : mqtt5.Mqtt5WebsocketUrlFactoryType = websocketConfig.urlFactoryOptions.urlFactory;

--- a/lib/native/auth.ts
+++ b/lib/native/auth.ts
@@ -130,6 +130,10 @@ export class AwsCredentialsProvider extends crt_native.AwsCredentialsProvider {
      * @returns a new credentials provider that returns credentials sourced from the AWS Cognito Identity service
      */
     static newCognito(config: CognitoCredentialsProviderConfig): AwsCredentialsProvider {
+        if (config == null || config == undefined) {
+            throw new CrtError("AwsCredentialsProvider newCognito: Cognito config not defined");
+        }
+
         return super.newCognito(config,
             config.tlsContext != null ? config.tlsContext.native_handle() : new ClientTlsContext().native_handle(),
             config.bootstrap != null ? config.bootstrap.native_handle() : null,
@@ -300,7 +304,7 @@ export interface AwsSigningConfig extends auth.AwsSigningConfigBase {
 export async function aws_sign_request(request: HttpRequest, config: AwsSigningConfig): Promise<HttpRequest> {
     return new Promise((resolve, reject) => {
         try {
-            /* Note: if the body of request has not fully loaded, it will lead to an endless loop. 
+            /* Note: if the body of request has not fully loaded, it will lead to an endless loop.
              * User should set the signed_body_value of config to prevent this endless loop in this case */
             crt_native.aws_sign_request(request, config, (error_code) => {
                 if (error_code == 0) {
@@ -324,7 +328,7 @@ export async function aws_sign_request(request: HttpRequest, config: AwsSigningC
  *  (1) The canonical request generated during sigv4a signing of the request matches what is passed in
  *  (2) The signature passed in is a valid ECDSA signature of the hashed string-to-sign derived from the
  *  canonical request
- * 
+ *
  * @param request The HTTP request to sign.
  * @param config Configuration for signing.
  * @param expected_canonical_request String type of expected canonical request. Refer to XXX(link to doc?)

--- a/lib/native/aws_iot.ts
+++ b/lib/native/aws_iot.ts
@@ -161,6 +161,10 @@ export class AwsIotMqttConnectionConfigBuilder {
 
     private static configure_websocket_handshake(builder: AwsIotMqttConnectionConfigBuilder, options?: WebsocketConfig) {
         if (options) {
+            if (builder == null || builder == undefined) {
+                throw new CrtError("AwsIotMqttConnectionConfigBuilder configure_websocket_handshake: builder not defined");
+            }
+
             builder.params.websocket_handshake_transform = async (request, done) => {
                 const signing_config = options.create_signing_config?.()
                     ?? {

--- a/lib/native/http.ts
+++ b/lib/native/http.ts
@@ -545,6 +545,9 @@ export class HttpClientConnectionManager extends NativeResource {
      * @param connection - The connection to return
     */
     release(connection: HttpClientConnection) {
+        if (connection == null || connection == undefined) {
+            throw new CrtError("HttpClientConnectionManager release: connection not defined");
+        }
         crt_native.http_connection_manager_release(this.native_handle(), connection.native_handle());
     }
 

--- a/lib/native/http.ts
+++ b/lib/native/http.ts
@@ -233,6 +233,10 @@ export class HttpClientConnection extends HttpConnection {
         proxy_options?: HttpProxyOptions,
         handle?: any) {
 
+        if (socket_options == null || socket_options == undefined) {
+            throw new CrtError("HttpClientConnection constructor: socket_options not defined");
+        }
+
         super(handle
             ? handle
             : crt_native.http_connection_new(
@@ -483,6 +487,11 @@ export class HttpClientConnectionManager extends NativeResource {
         readonly tls_opts?: TlsConnectionOptions,
         readonly proxy_options?: HttpProxyOptions,
     ) {
+
+        if (socket_options == null || socket_options == undefined) {
+            throw new CrtError("HttpClientConnectionManager constructor: socket_options not defined");
+        }
+
         super(crt_native.http_connection_manager_new(
             bootstrap != null ? bootstrap.native_handle() : null,
             host,

--- a/lib/native/io.ts
+++ b/lib/native/io.ts
@@ -413,6 +413,9 @@ export namespace TlsContextOptions {
  */
 export abstract class TlsContext extends NativeResource {
     constructor(ctx_opt: TlsContextOptions) {
+        if (ctx_opt == null || ctx_opt == undefined) {
+            throw new CrtError("TlsContext constructor: ctx_opt not defined");
+        }
         super(crt_native.io_tls_ctx_new(
             ctx_opt.min_tls_version,
             ctx_opt.ca_filepath,

--- a/lib/native/io.ts
+++ b/lib/native/io.ts
@@ -24,6 +24,7 @@ import { NativeResource } from "./native_resource";
 import { TlsVersion, SocketType, SocketDomain } from '../common/io';
 import { Readable } from 'stream';
 export { TlsVersion, SocketType, SocketDomain } from '../common/io';
+import { CrtError } from './error';
 
 /**
  * Convert a native error code into a human-readable string
@@ -474,6 +475,9 @@ export class ServerTlsContext extends TlsContext {
  */
 export class TlsConnectionOptions extends NativeResource {
     constructor(readonly tls_ctx: TlsContext, readonly server_name?: string, readonly alpn_list: string[] = []) {
+        if (tls_ctx == null || tls_ctx == undefined) {
+            throw new CrtError("TlsConnectionOptions constructor: tls_ctx not defined");
+        }
         super(crt_native.io_tls_connection_options_new(
             tls_ctx.native_handle(),
             server_name,

--- a/lib/native/mqtt.ts
+++ b/lib/native/mqtt.ts
@@ -228,6 +228,11 @@ export class MqttClientConnection extends NativeResourceMixin(BufferedEventEmitt
      */
     constructor(readonly client: MqttClient, private config: MqttConnectionConfig) {
         super();
+
+        if (config == null || config == undefined) {
+            throw new CrtError("MqttClientConnection constructor: config not defined");
+        }
+
         // If there is a will, ensure that its payload is normalized to a DataView
         const will = config.will ?
             {
@@ -298,7 +303,7 @@ export class MqttClientConnection extends NativeResourceMixin(BufferedEventEmitt
     static CONNECT = 'connect';
 
     /**
-     * Emitted when connection has disconnected sucessfully.
+     * Emitted when connection has disconnected successfully.
      *
      * @event
      */

--- a/lib/native/mqtt.ts
+++ b/lib/native/mqtt.ts
@@ -97,7 +97,7 @@ export interface MqttConnectionConfig {
     /** Server port to connect to */
     port: number;
 
-    /** Optional socket options */
+    /** Socket options */
     socket_options: io.SocketOptions;
 
     /** If true, connect to MQTT over websockets */
@@ -253,6 +253,13 @@ export class MqttClientConnection extends NativeResourceMixin(BufferedEventEmitt
             min_sec = Math.min(min_sec, max_sec);
         }
 
+        if (client == undefined || client == null) {
+            throw new CrtError("MqttClientConnection constructor: client not defined");
+        }
+        if (config.socket_options == undefined || config.socket_options == null) {
+            throw new CrtError("MqttClientConnection constructor: socket_options in configuration not defined");
+        }
+
         this._super(crt_native.mqtt_client_connection_new(
             client.native_handle(),
             (error_code: number) => { this._on_connection_interrupted(error_code); },
@@ -360,6 +367,10 @@ export class MqttClientConnection extends NativeResourceMixin(BufferedEventEmitt
     async connect() {
         return new Promise<boolean>((resolve, reject) => {
             reject = this._reject(reject);
+
+            if (this.config.socket_options == null || this.config.socket_options == undefined) {
+                throw new CrtError("MqttClientConnection connect: socket_options in configuration not defined");
+            }
 
             try {
                 crt_native.mqtt_client_connection_connect(

--- a/source/mqtt_client_connection.c
+++ b/source/mqtt_client_connection.c
@@ -699,7 +699,7 @@ napi_value aws_napi_mqtt_client_connection_connect(napi_env env, napi_callback_i
     size_t num_args = AWS_ARRAY_SIZE(node_args);
     napi_value *arg = &node_args[0];
     AWS_NAPI_CALL(env, napi_get_cb_info(env, cb_info, &num_args, node_args, NULL, NULL), {
-        napi_throw_error(env, NULL, "Failed to retreive callback information");
+        napi_throw_error(env, NULL, "Failed to retrieve callback information");
         goto cleanup;
     });
     if (num_args != AWS_ARRAY_SIZE(node_args)) {


### PR DESCRIPTION
*Issue #, if available:*

Fixes https://github.com/aws/aws-iot-device-sdk-js-v2/issues/93

*Description of changes:*

Adjusts the Typescript code to check if arguments are `null` or `undefined` IF their properties or methods are being accessed and the argument is non-optional. While this should never occur, and we have checks in the C code to make sure the arguments are non-null, we have several cases where we take an argument, call something like `example.native_handle()` but do not check if `native_handle` is defined or not before doing so. For Typescript, this is not an issue because Typescript will not allow you to pass `null` or `undefined`, but the NodeJS CRT (and extension IoT SDK) are used by those with Javascript, which does not have this typing guarantee.

This can lead to customers getting issues like `TypeError: Cannot read property 'native_handle' of undefined` when they miss a property. This PR changes it so the error returned will be `Error: MqttClientConnection constructor: socket_options in configuration not defined`.

This PR also fixes a number of small typos in the documentation I found while going through all the Typescript code, as well as marking `socket_options` as NOT optional for MQTT connections, as the code does not allow making it `null`/`undefined` (even prior to this PR) and even if we pass `null` to the C code, in aws-c-mqtt we deference the pointer and this would lead to a crash.

__________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
