### PR TITLE
Eventstream client integration

### DIFF
--- a/lib/browser.ts
+++ b/lib/browser.ts
@@ -10,6 +10,7 @@ import './browser/polyfills';
 /* common libs */
 import * as cancel from './common/cancel';
 import * as platform from './common/platform';
+import * as promise from './common/promise';
 import * as resource_safety from './common/resource_safety';
 
 /* browser specific libs */
@@ -32,6 +33,7 @@ export {
     mqtt,
     mqtt5,
     platform,
+    promise,
     resource_safety,
     ICrtError,
     CrtError

--- a/lib/browser.ts
+++ b/lib/browser.ts
@@ -8,6 +8,7 @@
 import './browser/polyfills';
 
 /* common libs */
+import * as cancel from './common/cancel';
 import * as platform from './common/platform';
 import * as resource_safety from './common/resource_safety';
 
@@ -23,6 +24,7 @@ import { ICrtError, CrtError } from './browser/error';
 
 export {
     auth,
+    cancel,
     crypto,
     http,
     io,

--- a/lib/common/cancel.spec.ts
+++ b/lib/common/cancel.spec.ts
@@ -4,6 +4,7 @@
  */
 
 import * as cancel from "./cancel";
+import {EventEmitter} from "events";
 
 jest.setTimeout(10000);
 
@@ -34,4 +35,49 @@ test('Simple cancel test - before await', async () => {
 
     // @ts-ignore
     expect(controller.emitter.listenerCount(cancel.EVENT_NAME)).toEqual(0);
+});
+
+test('Cancellable next event promise - event resolve', async () => {
+    const eventName : string = "DISASTER";
+    let controller : cancel.CancelController = new cancel.CancelController();
+    let emitter : EventEmitter = new EventEmitter();
+
+    let nextEventPromise : Promise<string> = cancel.newCancellablePromiseFromNextEvent({
+        cancelController: controller,
+        emitter : emitter,
+        eventName : eventName,
+        eventDataTransformer : (value : any) => { return value.toString(); },
+        cancelMessage : "Won't happen"
+    });
+
+    setTimeout(() => { emitter.emit(eventName, 1); });
+
+    let result : string = await nextEventPromise;
+    expect(result).toEqual("1");
+
+    // @ts-ignore
+    expect(controller.emitter.listenerCount(cancel.EVENT_NAME)).toEqual(0);
+    expect(emitter.listenerCount(eventName)).toEqual(0);
+});
+
+test('Cancellable next event promise - cancel reject', async () => {
+    const eventName : string = "DISASTER";
+    let controller : cancel.CancelController = new cancel.CancelController();
+    let emitter : EventEmitter = new EventEmitter();
+
+    let nextEventPromise : Promise<string> = cancel.newCancellablePromiseFromNextEvent({
+        cancelController: controller,
+        emitter : emitter,
+        eventName : eventName,
+        eventDataTransformer : (value : any) => { return value.toString(); },
+        cancelMessage : "Will happen"
+    });
+
+    setTimeout(() => { controller.cancel(); });
+
+    await expect(nextEventPromise).rejects.toMatch("Will happen");
+
+    // @ts-ignore
+    expect(controller.emitter.listenerCount(cancel.EVENT_NAME)).toEqual(0);
+    expect(emitter.listenerCount(eventName)).toEqual(0);
 });

--- a/lib/common/cancel.spec.ts
+++ b/lib/common/cancel.spec.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+import * as cancel from "./cancel";
+
+jest.setTimeout(10000);
+
+test('Simple cancel test', async () => {
+    let controller : cancel.CancelController = new cancel.CancelController();
+
+    let emptyPromise : Promise<void> = new Promise<void>((resolve, reject) => {
+       controller.registerListener(() => { resolve(); });
+    });
+
+    setTimeout(() => {controller.cancel();}, 1000);
+
+    await emptyPromise;
+});

--- a/lib/common/cancel.spec.ts
+++ b/lib/common/cancel.spec.ts
@@ -7,7 +7,7 @@ import * as cancel from "./cancel";
 
 jest.setTimeout(10000);
 
-test('Simple cancel test', async () => {
+test('Simple cancel test - after await', async () => {
     let controller : cancel.CancelController = new cancel.CancelController();
 
     let emptyPromise : Promise<void> = new Promise<void>((resolve, reject) => {
@@ -15,6 +15,17 @@ test('Simple cancel test', async () => {
     });
 
     setTimeout(() => {controller.cancel();}, 1000);
+
+    await emptyPromise;
+});
+
+test('Simple cancel test - before await', async () => {
+    let controller : cancel.CancelController = new cancel.CancelController();
+    controller.cancel();
+
+    let emptyPromise : Promise<void> = new Promise<void>((resolve, reject) => {
+        controller.registerListener(() => { resolve(); });
+    });
 
     await emptyPromise;
 });

--- a/lib/common/cancel.spec.ts
+++ b/lib/common/cancel.spec.ts
@@ -11,12 +11,15 @@ test('Simple cancel test - after await', async () => {
     let controller : cancel.CancelController = new cancel.CancelController();
 
     let emptyPromise : Promise<void> = new Promise<void>((resolve, reject) => {
-       controller.registerListener(() => { resolve(); });
+       controller.addListener(() => { resolve(); });
     });
 
     setTimeout(() => {controller.cancel();}, 1000);
 
     await emptyPromise;
+
+    // @ts-ignore
+    expect(controller.emitter.listenerCount(cancel.EVENT_NAME)).toEqual(0);
 });
 
 test('Simple cancel test - before await', async () => {
@@ -24,8 +27,11 @@ test('Simple cancel test - before await', async () => {
     controller.cancel();
 
     let emptyPromise : Promise<void> = new Promise<void>((resolve, reject) => {
-        controller.registerListener(() => { resolve(); });
+        controller.addListener(() => { resolve(); });
     });
 
     await emptyPromise;
+
+    // @ts-ignore
+    expect(controller.emitter.listenerCount(cancel.EVENT_NAME)).toEqual(0);
 });

--- a/lib/common/cancel.ts
+++ b/lib/common/cancel.ts
@@ -5,16 +5,46 @@
 
 import {EventEmitter} from "events";
 
+/**
+ * Abstract interface for an object capable of cancelling asynchronous operations.
+ *
+ * Modern browsers and Node 15+ include an AbortController which essentially does the same thing.  But our baseline
+ * is still node 10, so we provide our own implementation.  Also, Abort is, unfortunately, a problematic term, so we
+ * stick to Cancel.
+ */
 export interface ICancelController {
+
+    /**
+     * API to invoke to cancel all asynchronous operations connected to this controller
+     */
     cancel() : void;
 
+    /**
+     * Checks whether or not the controller is in the cancelled state
+     */
     hasBeenCancelled() : boolean;
 
+    /**
+     * Registers a callback to be notified when cancel() is invoked externally.  In general, the callback
+     * will cancel an asynchronous operation by rejecting the associated promise.
+     *
+     * IMPORTANT: The listener is invoked synchronously if the controller has already been cancelled.
+     *
+     * @param listener - function to invoke on cancel; invoked synchronously if the controller has been cancelled
+     *
+     * @return false if the controller has already been cancelled, true otherwise.  This is important because the
+     * usage pattern requires an early out (because the listener callback gets invoked, cancelling the promise)
+     * when the controller has already been cancelled.
+     *
+     */
     registerListener(listener: () => void) : boolean;
 }
 
 const EVENT_NAME = 'cancelled';
 
+/**
+ * CRT implementation of the ICancelController interface
+ */
 export class CancelController implements ICancelController {
 
     private cancelled : boolean;
@@ -25,6 +55,9 @@ export class CancelController implements ICancelController {
         this.emitter = new EventEmitter();
     }
 
+    /**
+     * Cancels all asynchronous operations associated with this controller
+     */
     public cancel() {
         if (!this.cancelled) {
             this.cancelled = true;
@@ -32,10 +65,26 @@ export class CancelController implements ICancelController {
         }
     }
 
+    /**
+     * Checks whether or not the controller is in the cancelled state
+     */
     public hasBeenCancelled() {
         return this.cancelled;
     }
 
+    /**
+     * Registers a callback to be notified when cancel() is invoked externally.  In general, the callback
+     * will cancel an asynchronous operation by rejecting the associated promise.
+     *
+     * IMPORTANT: The listener is invoked synchronously if the controller has already been cancelled.
+     *
+     * @param listener - function to invoke on cancel; invoked synchronously if the controller has been cancelled
+     *
+     * @return false if the controller has already been cancelled, true otherwise.  This is important because the
+     * usage pattern requires an early out (because the listener callback gets invoked, cancelling the promise)
+     * when the controller has already been cancelled.
+     *
+     */
     public registerListener(listener: () => void) : boolean {
         if (this.cancelled) {
             listener();

--- a/lib/common/cancel.ts
+++ b/lib/common/cancel.ts
@@ -51,18 +51,7 @@ export function makeSelfCleaningPromise<ResultType>(promise: Promise<ResultType>
         return promise;
     }
 
-    return promise.then(
-        (response) => {
-            cleaner();
-            return new Promise<ResultType>((resolve, reject) => {
-                resolve(response);
-            }); },
-        (err) => {
-            cleaner();
-            return new Promise<ResultType>((resolve,reject) => {
-                reject(err);
-            }); }
-    );
+    return promise.finally(() => { cleaner(); });
 }
 
 /**

--- a/lib/common/cancel.ts
+++ b/lib/common/cancel.ts
@@ -6,6 +6,66 @@
 import {EventEmitter} from "events";
 
 /**
+ * Callback signature for when cancel() has been invoked on a CancelController
+ */
+export type CancelListener = () => void;
+
+/**
+ * Signature for a function that will remove a listener from a CancelController's event emiiter
+ */
+export type RemoveListenerFunctor = () => void;
+
+/**
+ * A helper function that takes a promise (presumably one that has been made cancellable by attaching a listener to
+ * a CancelController) and creates a wrapper promise that removes the listener automatically when the inner promise
+ * is completed for any reason.  This allows us to keep the number of listeners on a CancelController bounded by
+ * the number of incomplete promises associated with it.  If we didn't clean up, the listener set would grow
+ * without limit.
+ *
+ * This leads to an internal usage pattern that is strongly recommended:
+ *
+ * ```
+ * async doSomethingCancellable(...) : Promise<...> {
+ *    removeListenerFunctor = undefined;
+ *
+ *    innerPromise = new Promise(async (resolve, reject) => {
+ *       ...
+ *
+ *       cancelListenerFunction = () => { clean up and reject innerPromise };
+ *       removeListenerFunctor = cancelController.addListener(cancelListenerFunction);
+ *
+ *       ...
+ *    }
+ *
+ *    return makeSelfCleaningPromise(innerPromise, removeListenerFunctor);
+ * }
+ * ```
+ *
+ * @param promise cancel-instrumented promise to automatically clean up for
+ * @param cleaner cleaner function to invoke when the promise is completed
+ *
+ * @return a promise with matching result/err, that invokes the cleaner function on inner promise completion
+ */
+export function makeSelfCleaningPromise<ResultType>(promise: Promise<ResultType>, cleaner? : RemoveListenerFunctor) : Promise<ResultType> {
+    if (!cleaner) {
+        return promise;
+    }
+
+    return promise.then(
+        (response) => {
+            cleaner();
+            return new Promise<ResultType>((resolve, reject) => {
+                resolve(response);
+            }); },
+        (err) => {
+            cleaner();
+            return new Promise<ResultType>((resolve,reject) => {
+                reject(err);
+            }); }
+    );
+}
+
+/**
  * Abstract interface for an object capable of cancelling asynchronous operations.
  *
  * Modern browsers and Node 15+ include an AbortController which essentially does the same thing.  But our baseline
@@ -30,17 +90,35 @@ export interface ICancelController {
      *
      * IMPORTANT: The listener is invoked synchronously if the controller has already been cancelled.
      *
-     * @param listener - function to invoke on cancel; invoked synchronously if the controller has been cancelled
+     * @param listener - function to invoke on cancel; invoked synchronously if the controller has already been
+     * cancelled
      *
-     * @return false if the controller has already been cancelled, true otherwise.  This is important because the
-     * usage pattern requires an early out (because the listener callback gets invoked, cancelling the promise)
-     * when the controller has already been cancelled.
+     * @return undefined if the controller has already been cancelled, otherwise a function object whose invocation
+     * will remove the listener from the controller's event emitter.
      *
      */
-    registerListener(listener: () => void) : boolean;
+    addListener(listener: CancelListener) : RemoveListenerFunctor | undefined;
+
 }
 
-const EVENT_NAME = 'cancelled';
+export const EVENT_NAME = 'cancelled';
+
+/**
+ * Signature for a factory function that can create EventEmitter objects
+ */
+export type EventEmitterFactory = () => EventEmitter;
+
+/**
+ * Configuration options for the CRT implementation of ICancelController
+ */
+export interface CancelControllerOptions {
+
+    /**
+     * Event emitters have, by default, a small maximum number of listeners.  When that default is insufficient for
+     * a use case, this factory option allows for customization of how the internal event emitter is created.
+     */
+    emitterFactory? : EventEmitterFactory;
+}
 
 /**
  * CRT implementation of the ICancelController interface
@@ -50,9 +128,14 @@ export class CancelController implements ICancelController {
     private cancelled : boolean;
     private emitter : EventEmitter;
 
-    public constructor() {
+    public constructor(options?: CancelControllerOptions) {
         this.cancelled = false;
-        this.emitter = new EventEmitter();
+
+        if (options && options.emitterFactory) {
+            this.emitter = options.emitterFactory();
+        } else {
+            this.emitter = new EventEmitter();
+        }
     }
 
     /**
@@ -62,6 +145,7 @@ export class CancelController implements ICancelController {
         if (!this.cancelled) {
             this.cancelled = true;
             this.emitter.emit(EVENT_NAME);
+            this.emitter.removeAllListeners(EVENT_NAME);
         }
     }
 
@@ -80,18 +164,19 @@ export class CancelController implements ICancelController {
      *
      * @param listener - function to invoke on cancel; invoked synchronously if the controller has been cancelled
      *
-     * @return false if the controller has already been cancelled, true otherwise.  This is important because the
-     * usage pattern requires an early out (because the listener callback gets invoked, cancelling the promise)
-     * when the controller has already been cancelled.
+     * @return undefined if the controller has already been cancelled, otherwise a function object whose invocation
+     * will remove the listener from the controller's event emitter.
      *
      */
-    public registerListener(listener: () => void) : boolean {
+    public addListener(listener: CancelListener) : RemoveListenerFunctor | undefined {
         if (this.cancelled) {
             listener();
-            return false;
+            return undefined;
         }
 
         this.emitter.on(EVENT_NAME, listener);
-        return true;
+
+        return () => { this.emitter.removeListener(EVENT_NAME, listener); };
     }
+
 }

--- a/lib/common/cancel.ts
+++ b/lib/common/cancel.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+import {EventEmitter} from "events";
+
+export interface ICancelController {
+    cancel() : void;
+
+    hasBeenCancelled() : boolean;
+
+    registerListener(listener: () => void) : boolean;
+}
+
+const EVENT_NAME = 'cancelled';
+
+export class CancelController implements ICancelController {
+
+    private cancelled : boolean;
+    private emitter : EventEmitter;
+
+    public constructor() {
+        this.cancelled = false;
+        this.emitter = new EventEmitter();
+    }
+
+    public cancel() {
+        if (!this.cancelled) {
+            this.cancelled = true;
+            this.emitter.emit(EVENT_NAME);
+        }
+    }
+
+    public hasBeenCancelled() {
+        return this.cancelled;
+    }
+
+    public registerListener(listener: () => void) : boolean {
+        if (this.cancelled) {
+            listener();
+            return false;
+        }
+
+        this.emitter.on(EVENT_NAME, listener);
+        return true;
+    }
+}

--- a/lib/common/cancel.ts
+++ b/lib/common/cancel.ts
@@ -145,7 +145,7 @@ export interface CancellableNextEventPromiseOptions<ResultType> {
     /**
      * Optional cancel controller that can cancel the created promise
      */
-    cancelController? : CancelController;
+    cancelController? : ICancelController;
 
     /**
      * Event emitter to listen to for potential promise completion

--- a/lib/common/promise.spec.ts
+++ b/lib/common/promise.spec.ts
@@ -20,7 +20,7 @@ test('Lifted promise - reject', async () => {
 
     setImmediate(() => { liftedPromise.reject("Fail");});
 
-    await expect(liftedPromise.promise).rejects.toBeDefined();
+    await expect(liftedPromise.promise).rejects.toMatch("Fail");
 });
 
 test('Lifted promise - body function execution', async () => {

--- a/lib/common/promise.spec.ts
+++ b/lib/common/promise.spec.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+import * as promise from "./promise";
+
+jest.setTimeout(10000);
+
+test('Lifted promise - resolve', async () => {
+    let liftedPromise : promise.LiftedPromise<void> = promise.newLiftedPromise<void>();
+
+    setImmediate(() => { liftedPromise.resolve();});
+
+    await liftedPromise.promise;
+});
+
+test('Lifted promise - reject', async () => {
+    let liftedPromise : promise.LiftedPromise<void> = promise.newLiftedPromise<void>();
+
+    setImmediate(() => { liftedPromise.reject("Fail");});
+
+    await expect(liftedPromise.promise).rejects.toBeDefined();
+});
+
+test('Lifted promise - body function execution', async () => {
+    let liftedPromise : promise.LiftedPromise<void> = promise.newLiftedPromise<void>((resolve, reject) => {
+        resolve();
+    });
+
+    await liftedPromise.promise;
+});

--- a/lib/common/promise.ts
+++ b/lib/common/promise.ts
@@ -1,0 +1,129 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+/**
+ *
+ * A module containing promise-related utility types and functions
+ *
+ * @packageDocumentation
+ * @module promise
+ */
+
+/**
+ * Signature for a function that will perform some arbitrary promise-related cleanup task, like removing one or
+ * more event listeners from an EventEmitter.
+ */
+export type PromiseCleanupFunctor = () => void;
+
+/**
+ * A helper function that takes a promise and creates a wrapper promise that invokes a cleanup function when the inner
+ * promise is completed for any reason.  The primary use is to remove event listeners related to promise completion
+ * when the promise actually completes.  This allows us to keep the number of listeners on a CancelController bounded by
+ * the number of incomplete promises associated with it.  If we didn't clean up, the listener set would grow
+ * without limit.
+ *
+ * For cancellation, this leads to an internal usage pattern that is strongly recommended:
+ *
+ * ```
+ * async doSomethingCancellable(...) : Promise<...> {
+ *    removeListenerFunctor = undefined;
+ *
+ *    innerPromise = new Promise(async (resolve, reject) => {
+ *       ...
+ *
+ *       cancelListenerFunction = () => { clean up and reject innerPromise };
+ *       removeListenerFunctor = cancelController.addListener(cancelListenerFunction);
+ *
+ *       ...
+ *    }
+ *
+ *    return makeSelfCleaningPromise(innerPromise, removeListenerFunctor);
+ * }
+ * ```
+ *
+ * @param promise promise to wrap with automatic cleanup
+ * @param cleaner cleaner function to invoke when the promise is completed
+ *
+ * @return a promise with matching result/err, that invokes the cleaner function on inner promise completion
+ */
+export function makeSelfCleaningPromise<ResultType>(promise: Promise<ResultType>, cleaner? : PromiseCleanupFunctor) : Promise<ResultType> {
+    if (!cleaner) {
+        return promise;
+    }
+
+    return promise.finally(() => { cleaner(); });
+}
+
+/**
+ * Generic type signature for a promise resolution function
+ */
+export type LiftedResolver<ResultType> = (value : ResultType) => void;
+
+/**
+ * Generic type signature for a promise rejection function
+ */
+export type LiftedRejecter = (error? : any) => void;
+
+/**
+ * A promise variant that makes the resolve and reject functions available for external invocations.
+ *
+ * Useful for situations where you want to await for something that might never complete while still allowing
+ * the promise to be cancellable.
+ *
+ * You get around the potentially infinite await by not awaiting at all and instead letting external events trigger
+ * resolve and reject (in particular, CancelController).
+ */
+export interface LiftedPromise<ResultType> {
+
+    /**
+     * The actual promise whose resolve and reject methods have been exposed.
+     */
+    promise: Promise<ResultType>;
+
+    /**
+     * Resolve function for the associated promise
+     */
+    resolve: LiftedResolver<ResultType>;
+
+    /**
+     * Reject function for the associated promise
+     */
+    reject: LiftedRejecter;
+}
+
+/**
+ * Factory function to create a new LiftedPromise
+ *
+ * @param promiseBody optional body function to invoke as part of promise creation
+ *
+ * @return a promise whose resolve and reject methods have been lifted out of the internal body function and made
+ * available to external actors
+ */
+export function newLiftedPromise<ResultType>(promiseBody?: (resolve : LiftedResolver<ResultType>, reject : LiftedRejecter) => void) : LiftedPromise<ResultType> {
+    let localResolve : LiftedResolver<ResultType> | undefined = undefined;
+    let localReject : LiftedRejecter | undefined = undefined;
+
+    let promise = new Promise<ResultType>((resolve, reject) => {
+        localResolve = resolve;
+        localReject = reject;
+    });
+
+    if (!localResolve || !localReject) {
+        // should never happen
+        throw new Error("Failed to bind resolve and reject when making lifted promise");
+    }
+
+    if (promiseBody) {
+        promiseBody(localResolve, localReject);
+    }
+
+    return {
+        promise : promise,
+        resolve: localResolve,
+        reject : localReject
+    };
+}
+
+

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -6,6 +6,7 @@
 // This is the entry point for the AWS CRT nodejs native libraries
 
 /* common libs */
+import * as cancel from './common/cancel';
 import * as platform from './common/platform';
 import * as resource_safety from './common/resource_safety';
 
@@ -24,6 +25,7 @@ import { ICrtError, CrtError } from './native/error';
 
 export {
     auth,
+    cancel,
     checksums,
     crypto,
     crt,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -8,6 +8,7 @@
 /* common libs */
 import * as cancel from './common/cancel';
 import * as platform from './common/platform';
+import * as promise from './common/promise';
 import * as resource_safety from './common/resource_safety';
 
 /* node specific libs */
@@ -36,6 +37,7 @@ export {
     mqtt,
     mqtt5,
     platform,
+    promise,
     resource_safety,
     ICrtError,
     CrtError

--- a/lib/native/eventstream.spec.ts
+++ b/lib/native/eventstream.spec.ts
@@ -863,7 +863,7 @@ conditional_test(hasEchoServerEnvironment())('Eventstream stream failure - sendM
     connection.close();
 });
 
-test('Eventstream connection cancel - example.com', async () => {
+test('Eventstream connection cancel - example.com, cancel after connect', async () => {
     // hangs atm
     let connection: eventstream.ClientConnection = new eventstream.ClientConnection({
         hostName: "example.com",
@@ -874,6 +874,21 @@ test('Eventstream connection cancel - example.com', async () => {
 
     setTimeout(() => { controller.cancel(); }, 1000);
 
+    await expect(connection.connect({
+        cancelController : controller
+    })).rejects.toThrow("cancelled");
+});
+
+test('Eventstream connection cancel - example.com, cancel before connect', async () => {
+    // hangs atm
+    let connection: eventstream.ClientConnection = new eventstream.ClientConnection({
+        hostName: "example.com",
+        port: 22
+    });
+
+    let controller : cancel.CancelController = new cancel.CancelController();
+    controller.cancel();
+    
     await expect(connection.connect({
         cancelController : controller
     })).rejects.toThrow("cancelled");

--- a/lib/native/eventstream.spec.ts
+++ b/lib/native/eventstream.spec.ts
@@ -532,7 +532,7 @@ async function openPersistentEchoStream(connection: eventstream.ClientConnection
         try {
             let stream : eventstream.ClientStream = connection.newStream();
 
-            const activateResponse = once(stream, eventstream.ClientStream.STREAM_MESSAGE);
+            const activateResponse = once(stream, eventstream.ClientStream.MESSAGE);
 
             let message : eventstream.Message = {
                 type: eventstream.MessageType.ApplicationMessage
@@ -570,7 +570,7 @@ conditional_test(hasEchoServerEnvironment())('Eventstream stream success - activ
 
     let stream : eventstream.ClientStream = await openPersistentEchoStream(connection);
 
-    let streamEnded = once(stream, eventstream.ClientStream.STREAM_ENDED);
+    let streamEnded = once(stream, eventstream.ClientStream.ENDED);
 
     crt_native.event_stream_client_connection_close_internal(connection.native_handle());
 
@@ -586,8 +586,8 @@ conditional_test(hasEchoServerEnvironment())('Eventstream stream success - activ
 
     let stream : eventstream.ClientStream = connection.newStream();
 
-    const activateResponse = once(stream, eventstream.ClientStream.STREAM_MESSAGE);
-    const streamEnded = once(stream, eventstream.ClientStream.STREAM_ENDED);
+    const activateResponse = once(stream, eventstream.ClientStream.MESSAGE);
+    const streamEnded = once(stream, eventstream.ClientStream.ENDED);
 
     const payloadAsString = "{}";
 
@@ -627,7 +627,7 @@ conditional_test(hasEchoServerEnvironment())('Eventstream stream success - activ
 
     let stream : eventstream.ClientStream = await openPersistentEchoStream(connection);
 
-    const echoResponse = once(stream, eventstream.ClientStream.STREAM_MESSAGE);
+    const echoResponse = once(stream, eventstream.ClientStream.MESSAGE);
 
     const payloadAsString = "{}";
 
@@ -660,7 +660,7 @@ conditional_test(hasEchoServerEnvironment())('Eventstream stream success - clien
     let connection : eventstream.ClientConnection = await makeGoodConnection();
     let stream : eventstream.ClientStream = await openPersistentEchoStream(connection);
 
-    const streamEnded = once(stream, eventstream.ClientStream.STREAM_ENDED);
+    const streamEnded = once(stream, eventstream.ClientStream.ENDED);
 
     let message : eventstream.Message = {
         type: eventstream.MessageType.ApplicationMessage,
@@ -680,8 +680,8 @@ conditional_test(hasEchoServerEnvironment())('Eventstream stream failure - activ
     let connection : eventstream.ClientConnection = await makeGoodConnection();
     let stream : eventstream.ClientStream = connection.newStream();
 
-    const streamEnded = once(stream, eventstream.ClientStream.STREAM_ENDED);
-    const activateResponse = once(stream, eventstream.ClientStream.STREAM_MESSAGE);
+    const streamEnded = once(stream, eventstream.ClientStream.ENDED);
+    const activateResponse = once(stream, eventstream.ClientStream.MESSAGE);
 
     const payloadAsString = "{}";
 
@@ -708,8 +708,8 @@ conditional_test(hasEchoServerEnvironment())('Eventstream stream failure - send 
     let connection : eventstream.ClientConnection = await makeGoodConnection();
     let stream : eventstream.ClientStream = await openPersistentEchoStream(connection);
 
-    const streamEnded = once(stream, eventstream.ClientStream.STREAM_ENDED);
-    const echoResponse = once(stream, eventstream.ClientStream.STREAM_MESSAGE);
+    const streamEnded = once(stream, eventstream.ClientStream.ENDED);
+    const echoResponse = once(stream, eventstream.ClientStream.MESSAGE);
 
     let message : eventstream.Message = {
         type: eventstream.MessageType.ApplicationMessage,
@@ -764,7 +764,7 @@ conditional_test(hasEchoServerEnvironment())('Eventstream stream failure - send 
     let connection : eventstream.ClientConnection = await makeGoodConnection();
     let stream : eventstream.ClientStream = await openPersistentEchoStream(connection);
 
-    const streamEnded = once(stream, eventstream.ClientStream.STREAM_ENDED);
+    const streamEnded = once(stream, eventstream.ClientStream.ENDED);
 
     let message : eventstream.Message = {
         type: eventstream.MessageType.ApplicationMessage,

--- a/lib/native/eventstream.spec.ts
+++ b/lib/native/eventstream.spec.ts
@@ -4,6 +4,7 @@
  */
 
 import * as eventstream from './eventstream';
+import * as cancel from '../common/cancel';
 import {once} from "events";
 import crt_native from "./binding";
 import * as os from "os";
@@ -49,7 +50,7 @@ function makeGoodConfig() : eventstream.ClientConnectionOptions {
 conditional_test(hasEchoServerEnvironment())('Eventstream transport connection success echo server - await connect, close, and forget', async () => {
     let connection : eventstream.ClientConnection = new eventstream.ClientConnection(makeGoodConfig());
 
-    await connection.connect();
+    await connection.connect({});
 
     connection.close();
 });
@@ -59,7 +60,7 @@ conditional_test(hasEchoServerEnvironment())('Eventstream transport connection s
 
     let disconnected = once(connection, eventstream.ClientConnection.DISCONNECTION);
 
-    await connection.connect();
+    await connection.connect({});
 
     // simulate a socket closed by the remote endpoint scenario
     closeNativeConnectionInternal(connection);
@@ -75,7 +76,7 @@ conditional_test(hasEchoServerEnvironment())('Eventstream transport connection s
     let connection : eventstream.ClientConnection = new eventstream.ClientConnection(makeGoodConfig());
 
     // intentionally do not await to try and beat the native connection setup with a close call
-    connection.connect();
+    connection.connect({});
 
     connection.close();
 
@@ -85,7 +86,7 @@ conditional_test(hasEchoServerEnvironment())('Eventstream transport connection s
 async function doConnectionFailureTest(config : eventstream.ClientConnectionOptions) {
     let connection : eventstream.ClientConnection = new eventstream.ClientConnection(config);
 
-    await expect(connection.connect()).rejects;
+    await expect(connection.connect({})).rejects;
 
     connection.close();
 }
@@ -107,7 +108,7 @@ conditional_test(hasEchoServerEnvironment())('Eventstream transport connection f
 async function doProtocolConnectionSuccessTest1() {
     let connection : eventstream.ClientConnection = new eventstream.ClientConnection(makeGoodConfig());
 
-    await connection.connect();
+    await connection.connect({});
 
     const connectResponse = once(connection, eventstream.ClientConnection.PROTOCOL_MESSAGE);
 
@@ -142,7 +143,7 @@ conditional_test(hasEchoServerEnvironment())('Eventstream protocol connection su
 async function doProtocolConnectionSuccessTest2() {
     let connection : eventstream.ClientConnection = new eventstream.ClientConnection(makeGoodConfig());
 
-    await connection.connect();
+    await connection.connect({});
 
     let connectMessage: eventstream.Message = {
         type: eventstream.MessageType.Connect,
@@ -171,7 +172,7 @@ async function makeGoodConnection() : Promise<eventstream.ClientConnection> {
         try {
             let connection: eventstream.ClientConnection = new eventstream.ClientConnection(makeGoodConfig());
 
-            await connection.connect();
+            await connection.connect({});
 
             const connectResponse = once(connection, eventstream.ClientConnection.PROTOCOL_MESSAGE);
 
@@ -303,7 +304,7 @@ conditional_test(hasEchoServerEnvironment())('Eventstream connection success - s
 conditional_test(hasEchoServerEnvironment())('Eventstream protocol connection failure Echo Server - bad version', async () => {
     let connection : eventstream.ClientConnection = new eventstream.ClientConnection(makeGoodConfig());
 
-    await connection.connect();
+    await connection.connect({});
 
     const connectResponse = once(connection, eventstream.ClientConnection.PROTOCOL_MESSAGE);
     const disconnected = once(connection, eventstream.ClientConnection.DISCONNECTION);
@@ -409,9 +410,9 @@ conditional_test(hasEchoServerEnvironment())('Eventstream connection state failu
 conditional_test(hasEchoServerEnvironment())('Eventstream connection state failure - connect while connecting', async () => {
     let connection : eventstream.ClientConnection = new eventstream.ClientConnection(makeGoodConfig());
 
-    let connected : Promise<void> = connection.connect();
+    let connected : Promise<void> = connection.connect({});
 
-    await expect(connection.connect()).rejects.toThrow();
+    await expect(connection.connect({})).rejects.toThrow();
 
     await connected;
 
@@ -421,9 +422,9 @@ conditional_test(hasEchoServerEnvironment())('Eventstream connection state failu
 conditional_test(hasEchoServerEnvironment())('Eventstream connection state failure - connect while connected', async () => {
     let connection : eventstream.ClientConnection = new eventstream.ClientConnection(makeGoodConfig());
 
-    await connection.connect();
+    await connection.connect({});
 
-    await expect(connection.connect()).rejects.toThrow();
+    await expect(connection.connect({})).rejects.toThrow();
 
     connection.close();
 });
@@ -433,14 +434,14 @@ conditional_test(hasEchoServerEnvironment())('Eventstream connection state failu
 
     let disconnected = once(connection, eventstream.ClientConnection.DISCONNECTION);
 
-    await connection.connect();
+    await connection.connect({});
 
     // simulate a socket closed by the remote endpoint scenario
     closeNativeConnectionInternal(connection);
 
     await disconnected;
 
-    await expect(connection.connect()).rejects.toThrow();
+    await expect(connection.connect({})).rejects.toThrow();
 
     connection.close();
 });
@@ -450,7 +451,7 @@ conditional_test(hasEchoServerEnvironment())('Eventstream connection state failu
 
     let disconnected = once(connection, eventstream.ClientConnection.DISCONNECTION);
 
-    await connection.connect();
+    await connection.connect({});
 
     // simulate a socket closed by the remote endpoint scenario
     closeNativeConnectionInternal(connection);
@@ -467,7 +468,7 @@ conditional_test(hasEchoServerEnvironment())('Eventstream connection state failu
 
     let disconnected = once(connection, eventstream.ClientConnection.DISCONNECTION);
 
-    await connection.connect();
+    await connection.connect({});
 
     // simulate a socket closed by the remote endpoint scenario
     closeNativeConnectionInternal(connection);
@@ -488,13 +489,13 @@ conditional_test(hasEchoServerEnvironment())('Eventstream connection state failu
 
     connection.close();
 
-    await expect(connection.connect()).rejects.toThrow();
+    await expect(connection.connect({})).rejects.toThrow();
 });
 
 conditional_test(hasEchoServerEnvironment())('Eventstream connection state failure - newStream while closed', async () => {
     let connection : eventstream.ClientConnection = new eventstream.ClientConnection(makeGoodConfig());
 
-    await connection.connect();
+    await connection.connect({});
 
     connection.close();
 
@@ -504,7 +505,7 @@ conditional_test(hasEchoServerEnvironment())('Eventstream connection state failu
 conditional_test(hasEchoServerEnvironment())('Eventstream connection state failure - sendProtocolMessage while closed', async () => {
     let connection : eventstream.ClientConnection = new eventstream.ClientConnection(makeGoodConfig());
 
-    await connection.connect();
+    await connection.connect({});
 
     connection.close();
 
@@ -519,7 +520,7 @@ conditional_test(hasEchoServerEnvironment())('Eventstream stream success - creat
 
     let connection : eventstream.ClientConnection = new eventstream.ClientConnection(makeGoodConfig());
 
-    await connection.connect();
+    await connection.connect({});
 
     let stream : eventstream.ClientStream = connection.newStream();
 
@@ -860,4 +861,20 @@ conditional_test(hasEchoServerEnvironment())('Eventstream stream failure - sendM
 
     stream.close();
     connection.close();
+});
+
+test('Eventstream connection cancel - example.com', async () => {
+    // hangs atm
+    let connection: eventstream.ClientConnection = new eventstream.ClientConnection({
+        hostName: "example.com",
+        port: 22
+    });
+
+    let controller : cancel.CancelController = new cancel.CancelController();
+
+    setTimeout(() => { controller.cancel(); }, 1000);
+
+    await expect(connection.connect({
+        cancelController : controller
+    })).rejects.toThrow("cancelled");
 });

--- a/lib/native/eventstream.spec.ts
+++ b/lib/native/eventstream.spec.ts
@@ -9,7 +9,7 @@ import {once} from "events";
 import crt_native from "./binding";
 import * as os from "os";
 
-jest.setTimeout(10000000);
+jest.setTimeout(10000);
 
 function hasEchoServerEnvironment() : boolean {
     if (process.env.AWS_TEST_EVENT_STREAM_ECHO_SERVER_HOST === undefined) {

--- a/lib/native/eventstream.ts
+++ b/lib/native/eventstream.ts
@@ -501,7 +501,13 @@ export interface ClientConnectionOptions {
     tlsCtx?: io.ClientTlsContext;
 }
 
+/**
+ * Options for opening a connection to an eventstream server
+ */
 export interface ConnectOptions {
+    /**
+     * Optional controller that allows the cancellation of asynchronous eventstream operations
+     */
     cancelController?: cancel.ICancelController;
 }
 
@@ -515,6 +521,9 @@ export interface ProtocolMessageOptions {
      */
     message: Message;
 
+    /**
+     * Optional controller that allows the cancellation of asynchronous eventstream operations
+     */
     cancelController?: cancel.ICancelController;
 }
 
@@ -549,6 +558,9 @@ export interface StreamMessageOptions {
      */
     message: Message;
 
+    /**
+     * Optional controller that allows the cancellation of asynchronous eventstream operations
+     */
     cancelController?: cancel.ICancelController;
 }
 

--- a/lib/native/eventstream.ts
+++ b/lib/native/eventstream.ts
@@ -9,6 +9,7 @@ import {CrtError} from "./error";
 import * as io from "./io";
 import * as eventstream_utils from "./eventstream_utils";
 import * as cancel from "../common/cancel";
+import * as promise from "../common/promise";
 import crt_native from "./binding";
 
 /**
@@ -682,7 +683,7 @@ export class ClientConnection extends NativeResourceMixin(BufferedEventEmitter) 
      * connect() may only be called once.
      */
     async connect(options: ConnectOptions) : Promise<void> {
-        let cleanupCancelListener : cancel.RemoveListenerFunctor | undefined = undefined;
+        let cleanupCancelListener : promise.PromiseCleanupFunctor | undefined = undefined;
 
         let connectPromise : Promise<void> = new Promise<void>((resolve, reject) => {
             if (!options) {
@@ -721,7 +722,7 @@ export class ClientConnection extends NativeResourceMixin(BufferedEventEmitter) 
             }
         });
 
-        return cancel.makeSelfCleaningPromise(connectPromise, cleanupCancelListener);
+        return promise.makeSelfCleaningPromise(connectPromise, cleanupCancelListener);
     }
 
     /**
@@ -733,7 +734,7 @@ export class ClientConnection extends NativeResourceMixin(BufferedEventEmitter) 
      * an error occurs prior to that point.
      */
     async sendProtocolMessage(options: ProtocolMessageOptions) : Promise<void> {
-        let cleanupCancelListener : cancel.RemoveListenerFunctor | undefined = undefined;
+        let cleanupCancelListener : promise.PromiseCleanupFunctor | undefined = undefined;
 
         let sendProtocolMessagePromise : Promise<void> = new Promise<void>((resolve, reject) => {
             try {
@@ -771,7 +772,7 @@ export class ClientConnection extends NativeResourceMixin(BufferedEventEmitter) 
             }
         });
 
-        return cancel.makeSelfCleaningPromise(sendProtocolMessagePromise, cleanupCancelListener);
+        return promise.makeSelfCleaningPromise(sendProtocolMessagePromise, cleanupCancelListener);
     }
 
     /**
@@ -948,7 +949,7 @@ export class ClientStream extends NativeResourceMixin(BufferedEventEmitter) {
      * @param options -- configuration data for stream activation, including operation name and initial message
      */
     async activate(options: ActivateStreamOptions) : Promise<void> {
-        let cleanupCancelListener : cancel.RemoveListenerFunctor | undefined = undefined;
+        let cleanupCancelListener : promise.PromiseCleanupFunctor | undefined = undefined;
 
         let activatePromise : Promise<void> = new Promise<void>((resolve, reject) => {
             try {
@@ -992,7 +993,7 @@ export class ClientStream extends NativeResourceMixin(BufferedEventEmitter) {
             }
         });
 
-        return cancel.makeSelfCleaningPromise<void>(activatePromise, cleanupCancelListener);
+        return promise.makeSelfCleaningPromise<void>(activatePromise, cleanupCancelListener);
     }
 
     /**
@@ -1004,7 +1005,7 @@ export class ClientStream extends NativeResourceMixin(BufferedEventEmitter) {
      * an error occurs prior to that point.
      */
     async sendMessage(options: StreamMessageOptions) : Promise<void> {
-        let cleanupCancelListener : cancel.RemoveListenerFunctor | undefined = undefined;
+        let cleanupCancelListener : promise.PromiseCleanupFunctor | undefined = undefined;
 
         let sendMessagePromise : Promise<void> = new Promise<void>((resolve, reject) => {
             try {
@@ -1041,7 +1042,7 @@ export class ClientStream extends NativeResourceMixin(BufferedEventEmitter) {
             }
         });
 
-        return cancel.makeSelfCleaningPromise<void>(sendMessagePromise, cleanupCancelListener);
+        return promise.makeSelfCleaningPromise<void>(sendMessagePromise, cleanupCancelListener);
     }
 
     /**

--- a/lib/native/eventstream.ts
+++ b/lib/native/eventstream.ts
@@ -976,9 +976,9 @@ export class ClientStream extends NativeResourceMixin(BufferedEventEmitter) {
      */
     static MESSAGE : string = 'message';
 
-    on(event: 'streamEnded', listener: StreamEndedListener): this;
+    on(event: 'ended', listener: StreamEndedListener): this;
 
-    on(event: 'streamMessage', listener: MessageListener): this;
+    on(event: 'message', listener: MessageListener): this;
 
     on(event: string | symbol, listener: (...args: any[]) => void): this {
         super.on(event, listener);

--- a/lib/native/eventstream.ts
+++ b/lib/native/eventstream.ts
@@ -67,7 +67,7 @@ export enum HeaderType {
  * Payloads are allowed to be any of the these types in an outbound message.
  * Payloads will always be ArrayBuffers when emitting received messages.
  */
-export type Payload = string | Record<string, unknown> | ArrayBuffer | ArrayBufferView;
+export type Payload = string | ArrayBuffer | ArrayBufferView;
 
 const AWS_MAXIMUM_EVENT_STREAM_HEADER_NAME_LENGTH : number = 127;
 

--- a/lib/native/eventstream.ts
+++ b/lib/native/eventstream.ts
@@ -694,7 +694,6 @@ export class ClientConnection extends NativeResourceMixin(BufferedEventEmitter) 
                     setImmediate(() => { this.close(); });
                 };
                 if (!options.cancelController.registerListener(cancel)) {
-                    cancel();
                     return;
                 }
             }
@@ -741,7 +740,6 @@ export class ClientConnection extends NativeResourceMixin(BufferedEventEmitter) 
                     setImmediate(() => { this.close(); });
                 };
                 if (!options.cancelController.registerListener(cancel)) {
-                    cancel();
                     return;
                 }
             }
@@ -946,7 +944,6 @@ export class ClientStream extends NativeResourceMixin(BufferedEventEmitter) {
                     setImmediate(() => { this.close(); });
                 };
                 if (!options.cancelController.registerListener(cancel)) {
-                    cancel();
                     return;
                 }
             }
@@ -1002,7 +999,6 @@ export class ClientStream extends NativeResourceMixin(BufferedEventEmitter) {
                     setImmediate(() => { this.close(); });
                 };
                 if (!options.cancelController.registerListener(cancel)) {
-                    cancel();
                     return;
                 }
             }


### PR DESCRIPTION
A bunch of miscellaneous CRT updates to support eventstream and Greengrass RPC.

* Some events have been renamed
* Added support for LiftedPromise, a promise whose resolve and reject methods are available to external actors.  Primary use is to remove internal awaits in the promise body that may never resolve (based on network events, for example) and instead let  external events drive resolution/rejection
* Added support for CancelController, a simple type with a cancel method that can be listened to for promise rejection

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
