### PR TITLE
Add shim needed for Angular support

### DIFF
--- a/lib/browser/polyfills.ts
+++ b/lib/browser/polyfills.ts
@@ -10,6 +10,8 @@ import process from 'process';
 if (window) {
     (window as any).Buffer = buffer.Buffer;
     (window as any).process = process;
+    // NodeJS global shim workaround for Angular
+    (window as any).global = window;
 }
 
 export {};


### PR DESCRIPTION
*Description of changes:*

With the addition of React support in #428, Angular almost works, but without a shim for `globals`, Angular doesn't work out of the box. This PR adds the shim to the polyfills so Angular works.

I tested the existing PubSub sample, the React sample in the `react_support` branch, and the Angular sample in the `angular_support` branch, and confirmed that in all cases the samples worked as expected. This change to add the shim needed for Angular shouldn't cause any changes to existing customers on any of the browser platforms.

__________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
