### PR TITLE
Add token_key_name and token_value support to MQTT311 custom auth

### DIFF
--- a/lib/browser/aws_iot.ts
+++ b/lib/browser/aws_iot.ts
@@ -251,12 +251,22 @@ export class AwsIotMqttConnectionConfigBuilder {
      *                       'x-amz-customauthorizer-name' will not be added with the MQTT connection.
      * @param authorizerSignature The signature of the custom authorizer. If an empty string is passed, then
      *                            'x-amz-customauthorizer-signature' will not be added with the MQTT connection.
+     *                            The signature must be based on the private key associated with the custom authorizer.
+     *                            The signature must be base64 encoded.
+     *                            Required if the custom authorizer has signing enabled.  It is strongly suggested to URL-encode
+     *                            this value; the SDK will not do so for you.
      * @param password The password to use with the custom authorizer. If null is passed, then no password will
      *                 be set.
+     * @param token_key_name Key used to extract the custom authorizer token from MQTT username query-string properties.
+     *                       Required if the custom authorizer has signing enabled.  It is strongly suggested to URL-encode
+     *                       this value; the SDK will not do so for you.
+     * @param token_value An opaque token value.
+     *                    Required if the custom authorizer has signing enabled. This value must be signed by the private
+     *                    key associated with the custom authorizer and the result placed in the token_signature argument.
      */
-    with_custom_authorizer(username : string, authorizer_name : string, authorizer_signature : string, password : string) {
+    with_custom_authorizer(username : string, authorizer_name : string, authorizer_signature : string, password : string, token_key_name? : string, token_value? : string) {
         let username_string = iot_shared.populate_username_string_with_custom_authorizer(
-            "", username, authorizer_name, authorizer_signature, this.params.username);
+            "", username, authorizer_name, authorizer_signature, this.params.username, token_key_name, token_value);
         this.params.username = username_string;
         this.params.password = password;
         // Tells the websocket connection we are using a custom authorizer

--- a/lib/common/aws_iot_shared.ts
+++ b/lib/common/aws_iot_shared.ts
@@ -58,7 +58,8 @@ import * as mqtt5_packet from "./mqtt5_packet";
  */
 export function populate_username_string_with_custom_authorizer(
     current_username? : string, input_username? : string, input_authorizer? : string,
-    input_signature? : string, input_builder_username? : string) {
+    input_signature? : string, input_builder_username? : string,
+    input_token_key_name? : string, input_token_value? : string) {
 
     let username_string = "";
 
@@ -77,8 +78,13 @@ export function populate_username_string_with_custom_authorizer(
     if (is_string_and_not_empty(input_authorizer) && input_authorizer) {
         username_string = add_to_username_parameter(username_string, input_authorizer, "x-amz-customauthorizer-name=");
     }
-    if (is_string_and_not_empty(input_signature) && input_signature) {
+
+    if (is_string_and_not_empty(input_token_value) || is_string_and_not_empty(input_token_key_name) || is_string_and_not_empty(input_signature)) {
+        if (!input_token_value || !input_token_key_name || !input_signature) {
+            throw new Error("Token-based custom authentication requires all token-related properties to be set");
+        }
         username_string = add_to_username_parameter(username_string, input_signature, "x-amz-customauthorizer-signature=");
+        username_string = add_to_username_parameter(username_string, input_token_value, input_token_key_name + "=");
     }
 
     return username_string;

--- a/lib/native/aws_iot.ts
+++ b/lib/native/aws_iot.ts
@@ -372,13 +372,23 @@ export class AwsIotMqttConnectionConfigBuilder {
      *                       'x-amz-customauthorizer-name' will not be added with the MQTT connection.
      * @param authorizerSignature The signature of the custom authorizer. If an empty string is passed, then
      *                            'x-amz-customauthorizer-signature' will not be added with the MQTT connection.
+     *                            The signature must be based on the private key associated with the custom authorizer.
+     *                            The signature must be base64 encoded.
+     *                            Required if the custom authorizer has signing enabled.  It is strongly suggested to URL-encode
+     *                            this value; the SDK will not do so for you.
      * @param password The password to use with the custom authorizer. If null is passed, then no password will
      *                 be set.
+     * @param token_key_name Key used to extract the custom authorizer token from MQTT username query-string properties.
+     *                       Required if the custom authorizer has signing enabled.  It is strongly suggested to URL-encode
+     *                       this value; the SDK will not do so for you.
+     * @param token_value An opaque token value.
+     *                    Required if the custom authorizer has signing enabled. This value must be signed by the private
+     *                    key associated with the custom authorizer and the result placed in the token_signature argument.
      */
-    with_custom_authorizer(username : string, authorizer_name : string, authorizer_signature : string, password : string) {
+    with_custom_authorizer(username : string, authorizer_name : string, authorizer_signature : string, password : string, token_key_name? : string, token_value? : string) {
         this.is_using_custom_authorizer = true;
         let username_string = iot_shared.populate_username_string_with_custom_authorizer(
-            "", username, authorizer_name, authorizer_signature, this.params.username);
+            "", username, authorizer_name, authorizer_signature, this.params.username, token_key_name, token_value);
         this.params.username = username_string;
         this.params.password = password;
         if (!this.params.use_websocket) {


### PR DESCRIPTION
*Description of changes:*

The current MQTT311 custom auth implementation is missing the ability to set the custom authorizer token key name and token key value, making it impossible to login with a signed custom authorizer using the builder.

This PR adds the support for the custom auth token key name and token key value. The change is completely backwards compatible as the new values are optional.

(Though the V2 SDKs will need to be updated because at least the browser refers to the custom auth signature as the "password" which is incorrect...)

________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
