### PR TITLE
PKCS12 builder support

### DIFF
--- a/.builder/actions/crt-ci-test.py
+++ b/.builder/actions/crt-ci-test.py
@@ -97,16 +97,16 @@ class CrtCiTest(Builder.Action):
         cert_file_name = None
         key_file_name = None
 
-        # PKCS12 setup (MacOS only)
-        if (sys.platform == "darwin"):
-            pkcs12_file_name = self._write_s3_to_temp_file(env, "s3://aws-crt-test-stuff/unit-test-key-pkcs12.pem")
-            env.shell.setenv("AWS_TEST_MQTT311_IOT_CORE_PKCS12_KEY", pkcs12_file_name)
-            env.shell.setenv("AWS_TEST_MQTT311_IOT_CORE_PKCS12_KEY_PASSWORD", "PKCS12_KEY_PASSWORD")
-
         try:
             java_sdk_dir = self._build_and_run_eventstream_echo_server(env)
 
             env.shell.setenv("AWS_TESTING_COGNITO_IDENTITY", env.shell.get_secret("aws-c-auth-testing/cognito-identity"), quiet=True)
+
+            # PKCS12 setup (MacOS only)
+            if (sys.platform == "darwin"):
+                pkcs12_file_name = self._write_s3_to_temp_file(env, "s3://aws-crt-test-stuff/unit-test-key-pkcs12.pem")
+                env.shell.setenv("AWS_TEST_MQTT311_IOT_CORE_PKCS12_KEY", pkcs12_file_name)
+                env.shell.setenv("AWS_TEST_MQTT311_IOT_CORE_PKCS12_KEY_PASSWORD", "PKCS12_KEY_PASSWORD")
 
             # Unfortunately, we can't use NamedTemporaryFile and a with-block because NamedTemporaryFile is not readable
             # on Windows.

--- a/.builder/actions/crt-ci-test.py
+++ b/.builder/actions/crt-ci-test.py
@@ -28,6 +28,19 @@ class CrtCiTest(Builder.Action):
 
         return filename
 
+    def _write_s3_to_temp_file(self, env, s3_file):
+        try:
+            tmp_file = tempfile.NamedTemporaryFile(delete=False)
+            tmp_file.flush()
+            tmp_s3_filepath = tmp_file.name
+            cmd = ['aws', '--region', 'us-east-1', 's3', 'cp',
+                    s3_file, tmp_s3_filepath]
+            env.shell.exec(*cmd, check=True, quiet=True)
+            return tmp_s3_filepath
+        except:
+            print (f"ERROR: Could not get S3 file from URL {s3_file}!")
+            raise RuntimeError("Could not get S3 file from URL")
+
     def _build_and_run_eventstream_echo_server(self, env):
         java_sdk_dir = None
 
@@ -83,6 +96,12 @@ class CrtCiTest(Builder.Action):
         java_sdk_dir = None
         cert_file_name = None
         key_file_name = None
+
+        # PKCS12 setup (MacOS only)
+        if (sys.platform == "darwin"):
+            pkcs12_file_name = self._write_s3_to_temp_file(env, "s3://aws-crt-test-stuff/unit-test-key-pkcs12.pem")
+            env.shell.setenv("AWS_TEST_MQTT311_IOT_CORE_PKCS12_KEY", pkcs12_file_name)
+            env.shell.setenv("AWS_TEST_MQTT311_IOT_CORE_PKCS12_KEY_PASSWORD", "PKCS12_KEY_PASSWORD")
 
         try:
             java_sdk_dir = self._build_and_run_eventstream_echo_server(env)

--- a/MQTT5-UserGuide.md
+++ b/MQTT5-UserGuide.md
@@ -20,6 +20,8 @@
     * [Direct MQTT with X509-based mutual TLS](#direct-mqtt-with-x509-based-mutual-tls)
     * [MQTT over Websockets with Sigv4 authentication](#mqtt-over-websockets-with-sigv4-authentication)
     * [Direct MQTT with Custom Authentication](#direct-mqtt-with-custom-authentication)
+    * [Direct MQTT with PKCS11](#direct-mqtt-with-pkcs11-method)
+    * [Direct MQTT with PKCS12](#direct-mqtt-with-pkcs12-method)
     * [HTTP Proxy](#http-proxy)
   * [Browser](#browser)
     * [MQTT over Websockets with Sigv4 authentication](#mqtt-over-websockets-with-sigv4-authentication-1)
@@ -266,6 +268,44 @@ In both cases, the builder will construct a final CONNECT packet username field 
 token-signing fields to the value of the username that you assign within the custom authentication config structure.  Similarly, do not
 add any custom authentication related values to the username in the CONNECT configuration optionally attached to the client configuration.
 The builder will do everything for you.
+
+#### Direct MQTT with PKCS11 Method
+
+A MQTT5 direct connection can be made using a PKCS11 device rather than using a PEM encoded private key, the private key for mutual TLS is stored on a PKCS#11 compatible smart card or Hardware Security Module (HSM). To create a MQTT5 builder configured for this connection, see the following code:
+
+```typescript
+    let pkcs11Options : Pkcs11Options = {
+        pkcs11_lib: "<path to PKCS11 library>",
+        user_pin: "<Optional pin for PKCS11 device>",
+        slot_id: "<Optional slot ID containing PKCS11 token>",
+        token_label: "<Optional label of the PKCS11 token>",
+        private_key_object_label: "<Optional label of the private key object on the PKCS#11 token>",
+        cert_file_path: "<Path to certificate file. Not necessary if cert_file_contents is used>",
+        cert_file_contents: "<Contents of certificate file. Not necessary if cert_file_path is used>"
+    };
+    let builder = AwsIotMqtt5ClientConfigBuilder.newDirectMqttBuilderWithCustomAuth(
+        "<account-specific endpoint>",
+        customAuthConfig
+    );
+    let client : Mqtt5Client = new mqtt5.Mqtt5Client(builder.build());
+```
+
+Note: Currently, TLS integration with PKCS#11 is only available on Unix devices.
+
+#### Direct MQTT with PKCS12 Method
+
+A MQTT5 direct connection can be made using a PKCS12 file rather than using a PEM encoded private key. To create a MQTT5 builder configured for this connection, see the following code:
+
+```typescript
+    let builder = AwsIotMqtt5ClientConfigBuilder.newDirectMqttBuilderWithMtlsFromPkcs12(
+        "<account-specific endpoint>",
+        "<PKCS12 file>",
+        "<PKCS12 password>"
+    );
+    let client : Mqtt5Client = new mqtt5.Mqtt5Client(builder.build());
+```
+
+Note: Currently, TLS integration with PKCS#12 is only available on MacOS devices.
 
 #### HTTP Proxy
 No matter what your connection transport or authentication method is, you may connect through an HTTP proxy

--- a/MQTT5-UserGuide.md
+++ b/MQTT5-UserGuide.md
@@ -283,9 +283,9 @@ A MQTT5 direct connection can be made using a PKCS11 device rather than using a 
         cert_file_path: "<Path to certificate file. Not necessary if cert_file_contents is used>",
         cert_file_contents: "<Contents of certificate file. Not necessary if cert_file_path is used>"
     };
-    let builder = AwsIotMqtt5ClientConfigBuilder.newDirectMqttBuilderWithCustomAuth(
+    let builder = AwsIotMqtt5ClientConfigBuilder.newDirectMqttBuilderWithMtlsFromPkcs11(
         "<account-specific endpoint>",
-        customAuthConfig
+        pkcs11Options
     );
     let client : Mqtt5Client = new mqtt5.Mqtt5Client(builder.build());
 ```

--- a/lib/native/aws_iot.spec.ts
+++ b/lib/native/aws_iot.spec.ts
@@ -13,7 +13,7 @@ import * as mqtt311 from "./mqtt";
 import * as aws_iot_mqtt311 from "./aws_iot";
 import { v4 as uuid } from 'uuid';
 
-test_utils.conditional_test(test_utils.ClientEnvironmentalConfig.hasIotCoreEnvironment())('Aws Iot Core Mqtt over websockets with Non-Signing Custom Auth - Connection Success', async () => {
+test_utils.conditional_test(test_utils.ClientEnvironmentalConfig.hasCustomAuthEnvironment())('Aws Iot Core Mqtt over websockets with Non-Signing Custom Auth - Connection Success', async () => {
 
     let builder = aws_iot_mqtt311.AwsIotMqttConnectionConfigBuilder.new_builder_for_websocket();
     builder.with_custom_authorizer(
@@ -33,7 +33,7 @@ test_utils.conditional_test(test_utils.ClientEnvironmentalConfig.hasIotCoreEnvir
     await connection.disconnect();
 });
 
-test_utils.conditional_test(test_utils.ClientEnvironmentalConfig.hasIotCoreEnvironment())('Aws Iot Core Mqtt over websockets with Signing Custom Auth - Connection Success', async () => {
+test_utils.conditional_test(test_utils.ClientEnvironmentalConfig.hasCustomAuthEnvironment())('Aws Iot Core Mqtt over websockets with Signing Custom Auth - Connection Success', async () => {
     let builder = aws_iot_mqtt311.AwsIotMqttConnectionConfigBuilder.new_builder_for_websocket();
     builder.with_custom_authorizer(
         test_utils.ClientEnvironmentalConfig.AWS_IOT_SIGNING_AUTHORIZER_USERNAME,
@@ -43,6 +43,19 @@ test_utils.conditional_test(test_utils.ClientEnvironmentalConfig.hasIotCoreEnvir
         test_utils.ClientEnvironmentalConfig.AWS_IOT_SIGNING_AUTHORIZER_TOKEN_KEY_NAME,
         test_utils.ClientEnvironmentalConfig.AWS_IOT_SIGNING_AUTHORIZER_TOKEN,
     )
+    builder.with_endpoint(test_utils.ClientEnvironmentalConfig.AWS_IOT_HOST);
+    builder.with_client_id(`node-mqtt-unit-test-${uuid()}`)
+    let config = builder.build();
+    let client = new mqtt311.MqttClient();
+    let connection = client.new_connection(config);
+    await connection.connect();
+    await connection.disconnect();
+});
+
+test_utils.conditional_test(test_utils.ClientEnvironmentalConfig.hasPKCS12Environment())('Aws Iot Core PKCS12 connection', async () => {
+    let builder = aws_iot_mqtt311.AwsIotMqttConnectionConfigBuilder.new_mtls_pkcs12_builder({
+        pkcs12_file : test_utils.ClientEnvironmentalConfig.AWS_TEST_MQTT311_IOT_CORE_PKCS12_KEY,
+        pkcs12_password : test_utils.ClientEnvironmentalConfig.AWS_TEST_MQTT311_IOT_CORE_PKCS12_KEY_PASSWORD});
     builder.with_endpoint(test_utils.ClientEnvironmentalConfig.AWS_IOT_HOST);
     builder.with_client_id(`node-mqtt-unit-test-${uuid()}`)
     let config = builder.build();

--- a/lib/native/aws_iot.ts
+++ b/lib/native/aws_iot.ts
@@ -50,6 +50,21 @@ export interface WebsocketConfig extends WebsocketOptionsBase{
 }
 
 /**
+ * Interface used to hold the options for creating a PKCS#12 connection in the builder.
+ *
+ * Note: Only supported on MacOS devices.
+ *
+ * @category IoT
+ */
+export interface Pkcs12Options {
+    /** Path to the PKCS#12 file */
+    pkcs12_file: string;
+
+    /** The password for the PKCS#12 file */
+    pkcs12_password : string;
+}
+
+/**
  * Builder functions to create a {@link MqttConnectionConfig} which can then be used to create
  * a {@link MqttClientConnection}, configured for use with AWS IoT.
  *
@@ -130,12 +145,13 @@ export class AwsIotMqttConnectionConfigBuilder {
     /**
      * Create a new builder with mTLS using a PKCS#12 file for private key operations.
      *
-     * NOTE: This configuration only works on MacOS devices.
-     * @param pkcs12_filepath - Path to the PKCS#12 file.
-     * @param pkcs12_password - Password for the PKCS12 file.
+     * Note: This configuration only works on MacOS devices.
+     *
+     * @param pkcs12_options - The PKCS#12 options to use in the builder.
      */
-    static new_mtls_pkcs12_builder(pkcs12_filepath: string, pkcs12_password: string) {
-        let builder = new AwsIotMqttConnectionConfigBuilder(TlsContextOptions.create_client_with_mtls_pkcs12_from_path(pkcs12_filepath, pkcs12_password));
+    static new_mtls_pkcs12_builder(pkcs12_options: Pkcs12Options) {
+        let builder = new AwsIotMqttConnectionConfigBuilder(TlsContextOptions.create_client_with_mtls_pkcs12_from_path(
+            pkcs12_options.pkcs12_file, pkcs12_options.pkcs12_password));
         builder.params.port = 8883;
 
         if (io.is_alpn_available()) {

--- a/lib/native/aws_iot.ts
+++ b/lib/native/aws_iot.ts
@@ -50,21 +50,6 @@ export interface WebsocketConfig extends WebsocketOptionsBase{
 }
 
 /**
- * Interface used to hold the options for creating a PKCS#12 connection in the builder.
- *
- * Note: Only supported on MacOS devices.
- *
- * @category IoT
- */
-export interface Pkcs12Options {
-    /** Path to the PKCS#12 file */
-    pkcs12_file: string;
-
-    /** The password for the PKCS#12 file */
-    pkcs12_password : string;
-}
-
-/**
  * Builder functions to create a {@link MqttConnectionConfig} which can then be used to create
  * a {@link MqttClientConnection}, configured for use with AWS IoT.
  *
@@ -149,7 +134,7 @@ export class AwsIotMqttConnectionConfigBuilder {
      *
      * @param pkcs12_options - The PKCS#12 options to use in the builder.
      */
-    static new_mtls_pkcs12_builder(pkcs12_options: Pkcs12Options) {
+    static new_mtls_pkcs12_builder(pkcs12_options: io.Pkcs12Options) {
         let builder = new AwsIotMqttConnectionConfigBuilder(TlsContextOptions.create_client_with_mtls_pkcs12_from_path(
             pkcs12_options.pkcs12_file, pkcs12_options.pkcs12_password));
         builder.params.port = 8883;

--- a/lib/native/aws_iot.ts
+++ b/lib/native/aws_iot.ts
@@ -128,6 +128,24 @@ export class AwsIotMqttConnectionConfigBuilder {
     }
 
     /**
+     * Create a new builder with mTLS using a PKCS#12 file for private key operations.
+     *
+     * NOTE: This configuration only works on MacOS devices.
+     * @param pkcs12_filepath - Path to the PKCS#12 file.
+     * @param pkcs12_password - Password for the PKCS12 file.
+     */
+    static new_mtls_pkcs12_builder(pkcs12_filepath: string, pkcs12_password: string) {
+        let builder = new AwsIotMqttConnectionConfigBuilder(TlsContextOptions.create_client_with_mtls_pkcs12_from_path(pkcs12_filepath, pkcs12_password));
+        builder.params.port = 8883;
+
+        if (io.is_alpn_available()) {
+            builder.tls_ctx_options.alpn_list.unshift('x-amzn-mqtt-ca');
+        }
+
+        return builder;
+    }
+
+    /**
      * Create a new builder with mTLS using a certificate in a Windows certificate store.
      *
      * NOTE: This configuration only works on Windows devices.

--- a/lib/native/aws_iot_mqtt5.spec.ts
+++ b/lib/native/aws_iot_mqtt5.spec.ts
@@ -188,3 +188,15 @@ test_utils.conditional_test(test_utils.ClientEnvironmentalConfig.hasIotCoreEnvir
 
     await test_utils.testConnect(new mqtt5.Mqtt5Client(builder.build()));
 });
+
+test_utils.conditional_test(test_utils.ClientEnvironmentalConfig.hasIotCoreEnvironment())('Aws Iot Core PKCS12 - Connection Success', async () => {
+    let builder = iot.AwsIotMqtt5ClientConfigBuilder.newDirectMqttBuilderWithMtlsFromPkcs12(
+        test_utils.ClientEnvironmentalConfig.AWS_IOT_HOST,
+        {
+            pkcs12_file : test_utils.ClientEnvironmentalConfig.AWS_TEST_MQTT311_IOT_CORE_PKCS12_KEY,
+            pkcs12_password : test_utils.ClientEnvironmentalConfig.AWS_TEST_MQTT311_IOT_CORE_PKCS12_KEY_PASSWORD
+        }
+    );
+    await test_utils.testConnect(new mqtt5.Mqtt5Client(builder.build()));
+});
+

--- a/lib/native/aws_iot_mqtt5.spec.ts
+++ b/lib/native/aws_iot_mqtt5.spec.ts
@@ -36,7 +36,7 @@ test_utils.conditional_test(test_utils.ClientEnvironmentalConfig.hasIotCoreEnvir
     await test_utils.testConnect(new mqtt5.Mqtt5Client(builder.build()));
 });
 
-test_utils.conditional_test(test_utils.ClientEnvironmentalConfig.hasIotCoreEnvironment())('Aws Iot Core Direct Mqtt Non-Signing Custom Auth - Connection Success', async () => {
+test_utils.conditional_test(test_utils.ClientEnvironmentalConfig.hasCustomAuthEnvironment())('Aws Iot Core Direct Mqtt Non-Signing Custom Auth - Connection Success', async () => {
     let customAuthConfig : iot.MqttConnectCustomAuthConfig = {
         authorizerName: test_utils.ClientEnvironmentalConfig.AWS_IOT_NO_SIGNING_AUTHORIZER_NAME,
         username: test_utils.ClientEnvironmentalConfig.AWS_IOT_NO_SIGNING_AUTHORIZER_USERNAME,
@@ -51,7 +51,7 @@ test_utils.conditional_test(test_utils.ClientEnvironmentalConfig.hasIotCoreEnvir
     await test_utils.testConnect(new mqtt5.Mqtt5Client(builder.build()));
 });
 
-test_utils.conditional_test(test_utils.ClientEnvironmentalConfig.hasIotCoreEnvironment())('Aws Iot Core Direct Mqtt Signing Custom Auth - Connection Success', async () => {
+test_utils.conditional_test(test_utils.ClientEnvironmentalConfig.hasCustomAuthEnvironment())('Aws Iot Core Direct Mqtt Signing Custom Auth - Connection Success', async () => {
     let customAuthConfig : iot.MqttConnectCustomAuthConfig = {
         authorizerName: test_utils.ClientEnvironmentalConfig.AWS_IOT_SIGNING_AUTHORIZER_NAME,
         username: test_utils.ClientEnvironmentalConfig.AWS_IOT_SIGNING_AUTHORIZER_USERNAME,
@@ -87,7 +87,7 @@ test_utils.conditional_test(test_utils.ClientEnvironmentalConfig.hasIotCoreEnvir
     await test_utils.testConnect(new mqtt5.Mqtt5Client(builder.build()));
 });
 
-test_utils.conditional_test(test_utils.ClientEnvironmentalConfig.hasIotCoreEnvironment())('Aws Iot Core Direct Mqtt Non-Signing Custom Auth - Connection Failure Bad Password', async () => {
+test_utils.conditional_test(test_utils.ClientEnvironmentalConfig.hasCustomAuthEnvironment())('Aws Iot Core Direct Mqtt Non-Signing Custom Auth - Connection Failure Bad Password', async () => {
     let customAuthConfig : iot.MqttConnectCustomAuthConfig = {
         authorizerName: test_utils.ClientEnvironmentalConfig.AWS_IOT_NO_SIGNING_AUTHORIZER_NAME,
         username: test_utils.ClientEnvironmentalConfig.AWS_IOT_NO_SIGNING_AUTHORIZER_USERNAME,
@@ -102,7 +102,7 @@ test_utils.conditional_test(test_utils.ClientEnvironmentalConfig.hasIotCoreEnvir
     await test_utils.testFailedConnection(new mqtt5.Mqtt5Client(builder.build()));
 });
 
-test_utils.conditional_test(test_utils.ClientEnvironmentalConfig.hasIotCoreEnvironment())('Aws Iot Core Direct Mqtt Signing Custom Auth - Connection Failure Bad Password', async () => {
+test_utils.conditional_test(test_utils.ClientEnvironmentalConfig.hasCustomAuthEnvironment())('Aws Iot Core Direct Mqtt Signing Custom Auth - Connection Failure Bad Password', async () => {
     let customAuthConfig : iot.MqttConnectCustomAuthConfig = {
         authorizerName: test_utils.ClientEnvironmentalConfig.AWS_IOT_SIGNING_AUTHORIZER_NAME,
         username: test_utils.ClientEnvironmentalConfig.AWS_IOT_SIGNING_AUTHORIZER_USERNAME,
@@ -120,7 +120,7 @@ test_utils.conditional_test(test_utils.ClientEnvironmentalConfig.hasIotCoreEnvir
     await test_utils.testFailedConnection(new mqtt5.Mqtt5Client(builder.build()));
 });
 
-test_utils.conditional_test(test_utils.ClientEnvironmentalConfig.hasIotCoreEnvironment())('Aws Iot Core Direct Mqtt Signing Custom Auth - Connection Failure Bad Token Value', async () => {
+test_utils.conditional_test(test_utils.ClientEnvironmentalConfig.hasCustomAuthEnvironment())('Aws Iot Core Direct Mqtt Signing Custom Auth - Connection Failure Bad Token Value', async () => {
     let customAuthConfig : iot.MqttConnectCustomAuthConfig = {
         authorizerName: test_utils.ClientEnvironmentalConfig.AWS_IOT_SIGNING_AUTHORIZER_NAME,
         username: test_utils.ClientEnvironmentalConfig.AWS_IOT_SIGNING_AUTHORIZER_USERNAME,
@@ -138,7 +138,7 @@ test_utils.conditional_test(test_utils.ClientEnvironmentalConfig.hasIotCoreEnvir
     await test_utils.testFailedConnection(new mqtt5.Mqtt5Client(builder.build()));
 });
 
-test_utils.conditional_test(test_utils.ClientEnvironmentalConfig.hasIotCoreEnvironment())('Aws Iot Core Direct Mqtt Signing Custom Auth - Connection Failure Bad Token Signature', async () => {
+test_utils.conditional_test(test_utils.ClientEnvironmentalConfig.hasCustomAuthEnvironment())('Aws Iot Core Direct Mqtt Signing Custom Auth - Connection Failure Bad Token Signature', async () => {
     let customAuthConfig : iot.MqttConnectCustomAuthConfig = {
         authorizerName: test_utils.ClientEnvironmentalConfig.AWS_IOT_SIGNING_AUTHORIZER_NAME,
         username: test_utils.ClientEnvironmentalConfig.AWS_IOT_SIGNING_AUTHORIZER_USERNAME,
@@ -156,7 +156,7 @@ test_utils.conditional_test(test_utils.ClientEnvironmentalConfig.hasIotCoreEnvir
     await test_utils.testFailedConnection(new mqtt5.Mqtt5Client(builder.build()));
 });
 
-test_utils.conditional_test(test_utils.ClientEnvironmentalConfig.hasIotCoreEnvironment())('Aws Iot Core Websocket Mqtt Non-Signing Custom Auth - Connection Success', async () => {
+test_utils.conditional_test(test_utils.ClientEnvironmentalConfig.hasCustomAuthEnvironment())('Aws Iot Core Websocket Mqtt Non-Signing Custom Auth - Connection Success', async () => {
     let customAuthConfig : iot.MqttConnectCustomAuthConfig = {
         authorizerName: test_utils.ClientEnvironmentalConfig.AWS_IOT_NO_SIGNING_AUTHORIZER_NAME,
         username: test_utils.ClientEnvironmentalConfig.AWS_IOT_NO_SIGNING_AUTHORIZER_USERNAME,
@@ -171,7 +171,7 @@ test_utils.conditional_test(test_utils.ClientEnvironmentalConfig.hasIotCoreEnvir
     await test_utils.testConnect(new mqtt5.Mqtt5Client(builder.build()));
 });
 
-test_utils.conditional_test(test_utils.ClientEnvironmentalConfig.hasIotCoreEnvironment())('Aws Iot Core Websocket Mqtt Signing Custom Auth - Connection Success', async () => {
+test_utils.conditional_test(test_utils.ClientEnvironmentalConfig.hasCustomAuthEnvironment())('Aws Iot Core Websocket Mqtt Signing Custom Auth - Connection Success', async () => {
     let customAuthConfig : iot.MqttConnectCustomAuthConfig = {
         authorizerName: test_utils.ClientEnvironmentalConfig.AWS_IOT_SIGNING_AUTHORIZER_NAME,
         username: test_utils.ClientEnvironmentalConfig.AWS_IOT_SIGNING_AUTHORIZER_USERNAME,
@@ -189,7 +189,7 @@ test_utils.conditional_test(test_utils.ClientEnvironmentalConfig.hasIotCoreEnvir
     await test_utils.testConnect(new mqtt5.Mqtt5Client(builder.build()));
 });
 
-test_utils.conditional_test(test_utils.ClientEnvironmentalConfig.hasIotCoreEnvironment())('Aws Iot Core PKCS12 - Connection Success', async () => {
+test_utils.conditional_test(test_utils.ClientEnvironmentalConfig.hasPKCS12Environment())('Aws Iot Core PKCS12 - Connection Success', async () => {
     let builder = iot.AwsIotMqtt5ClientConfigBuilder.newDirectMqttBuilderWithMtlsFromPkcs12(
         test_utils.ClientEnvironmentalConfig.AWS_IOT_HOST,
         {

--- a/lib/native/aws_iot_mqtt5.ts
+++ b/lib/native/aws_iot_mqtt5.ts
@@ -41,6 +41,21 @@ export interface WebsocketSigv4Config {
 }
 
 /**
+ * Interface used to hold the options for creating a PKCS#12 connection in the builder.
+ *
+ * Note: Only supported on MacOS devices.
+ *
+ * @category IoT
+ */
+export interface Pkcs12Options {
+    /** Path to the PKCS#12 file */
+    pkcs12_file: string;
+
+    /** The password for the PKCS#12 file */
+    pkcs12_password : string;
+}
+
+/**
  * Builder pattern class to create an {@link Mqtt5ClientConfig} which can then be used to create
  * an {@link Mqtt5Client}, configured for use with AWS IoT.
  *
@@ -144,17 +159,16 @@ export class AwsIotMqtt5ClientConfigBuilder {
      * Create a new MQTT5 client builder that will create MQTT5 clients that connect to AWS IoT Core via mutual TLS
      * using a PKCS12 file.
      *
-     * NOTE: This configuration only works on MacOS devices.
+     * Note: This configuration only works on MacOS devices.
      *
      * @param hostName - AWS IoT endpoint to connect to
-     * @param pkcs12_filepath - Path to the PKCS#12 file.
-     * @param pkcs12_password - Password for the PKCS12 file.
+     * @param pkcs12_options - The PKCS#12 options to use in the builder.
      */
-    static newDirectMqttBuilderWithMtlsFromPkcs12(hostName : string, pkcs12_filepath: string, pkcs12_password: string) : AwsIotMqtt5ClientConfigBuilder {
+    static newDirectMqttBuilderWithMtlsFromPkcs12(hostName : string, pkcs12_options: Pkcs12Options) : AwsIotMqtt5ClientConfigBuilder {
         let builder = new AwsIotMqtt5ClientConfigBuilder(
             hostName,
             AwsIotMqtt5ClientConfigBuilder.DEFAULT_DIRECT_MQTT_PORT,
-            io.TlsContextOptions.create_client_with_mtls_pkcs12_from_path(pkcs12_filepath, pkcs12_password));
+            io.TlsContextOptions.create_client_with_mtls_pkcs12_from_path(pkcs12_options.pkcs12_file, pkcs12_options.pkcs12_password));
 
         if (io.is_alpn_available()) {
             builder.tlsContextOptions.alpn_list.unshift('x-amzn-mqtt-ca');

--- a/lib/native/aws_iot_mqtt5.ts
+++ b/lib/native/aws_iot_mqtt5.ts
@@ -41,21 +41,6 @@ export interface WebsocketSigv4Config {
 }
 
 /**
- * Interface used to hold the options for creating a PKCS#12 connection in the builder.
- *
- * Note: Only supported on MacOS devices.
- *
- * @category IoT
- */
-export interface Pkcs12Options {
-    /** Path to the PKCS#12 file */
-    pkcs12_file: string;
-
-    /** The password for the PKCS#12 file */
-    pkcs12_password : string;
-}
-
-/**
  * Builder pattern class to create an {@link Mqtt5ClientConfig} which can then be used to create
  * an {@link Mqtt5Client}, configured for use with AWS IoT.
  *
@@ -164,7 +149,7 @@ export class AwsIotMqtt5ClientConfigBuilder {
      * @param hostName - AWS IoT endpoint to connect to
      * @param pkcs12_options - The PKCS#12 options to use in the builder.
      */
-    static newDirectMqttBuilderWithMtlsFromPkcs12(hostName : string, pkcs12_options: Pkcs12Options) : AwsIotMqtt5ClientConfigBuilder {
+    static newDirectMqttBuilderWithMtlsFromPkcs12(hostName : string, pkcs12_options: io.Pkcs12Options) : AwsIotMqtt5ClientConfigBuilder {
         let builder = new AwsIotMqtt5ClientConfigBuilder(
             hostName,
             AwsIotMqtt5ClientConfigBuilder.DEFAULT_DIRECT_MQTT_PORT,

--- a/lib/native/aws_iot_mqtt5.ts
+++ b/lib/native/aws_iot_mqtt5.ts
@@ -142,6 +142,29 @@ export class AwsIotMqtt5ClientConfigBuilder {
 
     /**
      * Create a new MQTT5 client builder that will create MQTT5 clients that connect to AWS IoT Core via mutual TLS
+     * using a PKCS12 file.
+     *
+     * NOTE: This configuration only works on MacOS devices.
+     *
+     * @param hostName - AWS IoT endpoint to connect to
+     * @param pkcs12_filepath - Path to the PKCS#12 file.
+     * @param pkcs12_password - Password for the PKCS12 file.
+     */
+    static newDirectMqttBuilderWithMtlsFromPkcs12(hostName : string, pkcs12_filepath: string, pkcs12_password: string) : AwsIotMqtt5ClientConfigBuilder {
+        let builder = new AwsIotMqtt5ClientConfigBuilder(
+            hostName,
+            AwsIotMqtt5ClientConfigBuilder.DEFAULT_DIRECT_MQTT_PORT,
+            io.TlsContextOptions.create_client_with_mtls_pkcs12_from_path(pkcs12_filepath, pkcs12_password));
+
+        if (io.is_alpn_available()) {
+            builder.tlsContextOptions.alpn_list.unshift('x-amzn-mqtt-ca');
+        }
+
+        return builder;
+    }
+
+    /**
+     * Create a new MQTT5 client builder that will create MQTT5 clients that connect to AWS IoT Core via mutual TLS
      * using a certificate entry in a Windows certificate store.
      *
      * NOTE: This configuration only works on Windows devices.

--- a/lib/native/io.ts
+++ b/lib/native/io.ts
@@ -161,6 +161,22 @@ export class SocketOptions extends NativeResource {
 }
 
 /**
+ * Interface used to hold the options for creating a PKCS#12 connection in the builder.
+ *
+ * Note: Only supported on MacOS devices.
+ *
+ * NodeJS only
+ * @category TLS
+ */
+export interface Pkcs12Options {
+    /** Path to the PKCS#12 file */
+    pkcs12_file: string;
+
+    /** The password for the PKCS#12 file */
+    pkcs12_password : string;
+}
+
+/**
  * Options for creating a {@link ClientTlsContext} or {@link ServerTlsContext}.
  *
  * nodejs only.

--- a/test/mqtt5.ts
+++ b/test/mqtt5.ts
@@ -59,10 +59,32 @@ export class ClientEnvironmentalConfig {
     public static AWS_IOT_SIGNING_AUTHORIZER_TOKEN_SIGNATURE = process.env.AWS_TEST_MQTT5_IOT_CORE_SIGNING_AUTHORIZER_TOKEN_SIGNATURE ?? "";
     public static AWS_IOT_SIGNING_AUTHORIZER_TOKEN_KEY_NAME = process.env.AWS_TEST_MQTT5_IOT_CORE_SIGNING_AUTHORIZER_TOKEN_KEY_NAME ?? "";
 
+    public static AWS_TEST_MQTT311_IOT_CORE_PKCS12_KEY = process.env.AWS_TEST_MQTT311_IOT_CORE_PKCS12_KEY ?? "";
+    public static AWS_TEST_MQTT311_IOT_CORE_PKCS12_KEY_PASSWORD = process.env.AWS_TEST_MQTT311_IOT_CORE_PKCS12_KEY_PASSWORD ?? "";
+
     public static hasIotCoreEnvironment() {
         return ClientEnvironmentalConfig.AWS_IOT_HOST !== "" &&
             ClientEnvironmentalConfig.AWS_IOT_CERTIFICATE_PATH !== "" &&
             ClientEnvironmentalConfig.AWS_IOT_KEY_PATH !== "";
+    }
+
+    public static hasCustomAuthEnvironment() {
+        return ClientEnvironmentalConfig.AWS_IOT_HOST !== "" &&
+            ClientEnvironmentalConfig.AWS_IOT_NO_SIGNING_AUTHORIZER_NAME != "" &&
+            ClientEnvironmentalConfig.AWS_IOT_NO_SIGNING_AUTHORIZER_USERNAME != "" &&
+            ClientEnvironmentalConfig.AWS_IOT_NO_SIGNING_AUTHORIZER_PASSWORD != "" &&
+            ClientEnvironmentalConfig.AWS_IOT_SIGNING_AUTHORIZER_NAME != "" &&
+            ClientEnvironmentalConfig.AWS_IOT_SIGNING_AUTHORIZER_USERNAME != "" &&
+            ClientEnvironmentalConfig.AWS_IOT_SIGNING_AUTHORIZER_PASSWORD != "" &&
+            ClientEnvironmentalConfig.AWS_IOT_SIGNING_AUTHORIZER_TOKEN != "" &&
+            ClientEnvironmentalConfig.AWS_IOT_SIGNING_AUTHORIZER_TOKEN_SIGNATURE != "" &&
+            ClientEnvironmentalConfig.AWS_IOT_SIGNING_AUTHORIZER_TOKEN_KEY_NAME != "";
+    }
+
+    public static hasPKCS12Environment() {
+        return ClientEnvironmentalConfig.AWS_IOT_HOST !== "" &&
+            ClientEnvironmentalConfig.AWS_TEST_MQTT311_IOT_CORE_PKCS12_KEY !== "" &&
+            ClientEnvironmentalConfig.AWS_TEST_MQTT311_IOT_CORE_PKCS12_KEY_PASSWORD !== ""
     }
 
     public static DIRECT_MQTT_HOST = process.env.AWS_TEST_MQTT5_DIRECT_MQTT_HOST ?? "";
@@ -415,7 +437,7 @@ export async function willTest(publisher: mqtt5.Mqtt5Client, subscriber: mqtt5.M
     publisher.stop({
         reasonCode: mqtt5.DisconnectReasonCode.DisconnectWithWillMessage
     });
-    
+
     await willReceived;
     await publisherStopped;
 


### PR DESCRIPTION
*Description of changes:*

Adds PKCS12 support to the MQTT311 and MQTT5 builders. Also adds PKCS11 and PKCS12 documentation to the MQTT5 user guide.

_________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
