### PR TITLE
Let's try ref counting

### DIFF
--- a/source/module.c
+++ b/source/module.c
@@ -1177,8 +1177,6 @@ static bool s_create_and_register_function(
     if (s_module_initialize_count == 0) {
         s_install_crash_handler();
 
-        aws_cal_library_init(allocator);
-        aws_http_library_init(allocator);
         aws_mqtt_library_init(allocator);
         aws_auth_library_init(allocator);
         aws_register_error_info(&s_error_list);


### PR DESCRIPTION
Revert the changes that prevented multi-init of the NAPI module and add ref-counting support and careful, matching shutdown when the last ref goes away.

https://github.com/aws/aws-iot-device-sdk-js-v2/discussions/360

A more complex solution might consider making elg/hr/bootstrap a per-environment set of data, but for now, the simplest approach with the least possibility of error is to simply have all environments reference a shared triple and use ref-counting to drop the triple once no env-users remain.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
