### PR TITLE
Adjust MQTT311 disconnect cleanup

### DIFF
--- a/lib/native/aws_iot.ts
+++ b/lib/native/aws_iot.ts
@@ -73,8 +73,7 @@ export class AwsIotMqttConnectionConfigBuilder {
             password: undefined,
             tls_ctx: undefined,
             reconnect_min_sec: DEFAULT_RECONNECT_MIN_SEC,
-            reconnect_max_sec: DEFAULT_RECONNECT_MAX_SEC,
-            close_on_disconnect: true
+            reconnect_max_sec: DEFAULT_RECONNECT_MAX_SEC
         };
         this.is_using_custom_authorizer = false
     }
@@ -455,23 +454,6 @@ export class AwsIotMqttConnectionConfigBuilder {
      */
     with_reconnect_min_sec(min_sec: number) {
         this.params.reconnect_min_sec = min_sec;
-        return this;
-    }
-
-    /**
-     * Sets whether calling disconnecting will trigger a cleanup of native resources associated with the MqttClientConnection
-     * automatically when the MqttClientConnection disconnect() function is called.
-     *
-     * **Defaults to true.** If set to false, you must manually call the MqttClientConnection close()
-     * function when you are done connection or native resources will leak.
-     *
-     * Note: **Once close() is called, whether automatically on disconnect or manually, it is not safe to invoke any
-     * further operations or functions on the MqttClientConnection.**
-     *
-     * @param close_on_disconnect whether the connection will automatically clean resources on disconnect()
-     */
-    with_close_on_disconnect(close_on_disconnect: boolean) {
-        this.params.close_on_disconnect = close_on_disconnect;
         return this;
     }
 

--- a/lib/native/aws_iot.ts
+++ b/lib/native/aws_iot.ts
@@ -73,7 +73,8 @@ export class AwsIotMqttConnectionConfigBuilder {
             password: undefined,
             tls_ctx: undefined,
             reconnect_min_sec: DEFAULT_RECONNECT_MIN_SEC,
-            reconnect_max_sec: DEFAULT_RECONNECT_MAX_SEC
+            reconnect_max_sec: DEFAULT_RECONNECT_MAX_SEC,
+            close_on_disconnect: true
         };
         this.is_using_custom_authorizer = false
     }
@@ -454,6 +455,23 @@ export class AwsIotMqttConnectionConfigBuilder {
      */
     with_reconnect_min_sec(min_sec: number) {
         this.params.reconnect_min_sec = min_sec;
+        return this;
+    }
+
+    /**
+     * Sets whether calling disconnecting will trigger a cleanup of native resources associated with the MqttClientConnection
+     * automatically when the MqttClientConnection disconnect() function is called.
+     *
+     * **Defaults to true.** If set to false, you must manually call the MqttClientConnection close()
+     * function when you are done connection or native resources will leak.
+     *
+     * Note: **Once close() is called, whether automatically on disconnect or manually, it is not safe to invoke any
+     * further operations or functions on the MqttClientConnection.**
+     *
+     * @param close_on_disconnect whether the connection will automatically clean resources on disconnect()
+     */
+    with_close_on_disconnect(close_on_disconnect: boolean) {
+        this.params.close_on_disconnect = close_on_disconnect;
         return this;
     }
 

--- a/lib/native/mqtt.ts
+++ b/lib/native/mqtt.ts
@@ -177,19 +177,6 @@ export interface MqttConnectionConfig {
     proxy_options?: HttpProxyOptions;
 
     /**
-     * Triggers cleanup of native resources associated with the {@link MqttClientConnection} by automatically
-     * calling the {@link MqttClientConnection} close() function when the {@link MqttClientConnection} disconnect()
-     * function has been called and the disconnection was successful.
-     *
-     * Defaults to true. If set to false, you must manually call the {@link MqttClientConnection} close()
-     * function when you are done connection or native resources will leak.
-     *
-     * Note: **Once close() is called, whether automatically on disconnect or manually, it is not safe to invoke any
-     * further operations or functions on the {@link MqttClientConnection}.**
-     */
-    close_on_disconnect?: boolean;
-
-    /**
      * Optional function to transform websocket handshake request.
      * If provided, function is called each time a websocket connection is attempted.
      * The function may modify the HTTP request before it is sent to the server.
@@ -234,7 +221,6 @@ export interface MqttConnectionConfig {
  */
 export class MqttClientConnection extends NativeResourceMixin(BufferedEventEmitter) {
     readonly tls_ctx?: io.ClientTlsContext; // this reference keeps the tls_ctx alive beyond the life of the connection
-    readonly close_on_disconnect?: boolean; // needed to track if close() should be called after disconnect()
 
     /**
      * @param client The client that owns this connection
@@ -279,13 +265,6 @@ export class MqttClientConnection extends NativeResourceMixin(BufferedEventEmitt
             throw new CrtError("MqttClientConnection constructor: socket_options in configuration not defined");
         }
 
-        // We need to track whether or not we automatically close the disconnect() callback or not.
-        // By default, we release ALL native resources when a call to disconnect() has been made but
-        // this means the customer can cannot manually disconnect and reconnect, which is possible in
-        // the other SDKs. Unfortunately, we have vended this default behavior for long enough that we
-        // need to support both workflows (freeing native resources on disconnect and manually)
-        this.close_on_disconnect = config.close_on_disconnect;
-
         this._super(crt_native.mqtt_client_connection_new(
             client.native_handle(),
             (error_code: number) => { this._on_connection_interrupted(error_code); },
@@ -312,33 +291,7 @@ export class MqttClientConnection extends NativeResourceMixin(BufferedEventEmitt
         this.on('error', (error) => {});
     }
 
-    /**
-     * Triggers cleanup of native resources associated with the MQTT connection.  Once this has been invoked,
-     * callbacks and events are not guaranteed to be received. Calling multiple times will result in an error
-     * being thrown.
-     *
-     * By default this will be automatically called when the disconnect() function is called and the
-     * client is successfully disconnected. This prevents manually reconnecting after calling disconnect().
-     * While this means you cannot reuse a connection after calling disconnect, it also means you do not need
-     * to worry about remembering to call close().
-     *
-     * If you have set close_on_disconnect to false, then you must call close() when finished with the connection
-     * or native resources will leak. With close_on_disconnect set to false, a safe and proper shutdown can be
-     * accomplished with the following:
-     *
-     * ```ts
-     * await connection.disconnect();
-     * connection.close();
-     * ```
-     *
-     * Calling close() is **only required if close_on_disconnect is set to false.**
-     *
-     * Note: **Once close() is called, whether automatically on disconnect or manually, it is not safe to invoke any
-     * further operations or functions on the MqttClientConnection.**
-     *
-     * @group Node-only
-     */
-    close() {
+    private close() {
         crt_native.mqtt_client_connection_close(this.native_handle());
     }
 
@@ -445,12 +398,7 @@ export class MqttClientConnection extends NativeResourceMixin(BufferedEventEmitt
 
     /**
      * The connection will automatically reconnect when disconnected, removing the need for this function.
-     *
      * To cease automatic reconnection attempts, call {@link disconnect}.
-     *
-     * Connections can be resumed by calling {@link connect}, though note that close_on_disconnect must be
-     * set to false, as otherwise {@link disconnect} will make the connection unable to reconnect.
-     *
      * @deprecated
      */
     async reconnect() {
@@ -546,7 +494,7 @@ export class MqttClientConnection extends NativeResourceMixin(BufferedEventEmitt
     /**
      * Close the connection (async).
      *
-     * By default will free all native resources, rendering the connection unusable after the disconnect() call.
+     * Will free all native resources, rendering the connection unusable after the disconnect() call.
      *
      * @returns Promise which completes when the connection is closed.
     */
@@ -635,10 +583,6 @@ export class MqttClientConnection extends NativeResourceMixin(BufferedEventEmitt
     private _on_disconnect_callback(resolve: (value?: (void | PromiseLike<void>)) => void) {
         resolve();
         this.emit('disconnect');
-
-        // Default behavior HAS to be to close for backwards compatibility
-        if (this.close_on_disconnect != false || this.close_on_disconnect == undefined) {
-            this.close();
-        }
+        this.close();
     }
 }


### PR DESCRIPTION
*Description of changes:*

~Adjusts MQTT311's disconnect behavior to not always free the native resources when `disconnect()` is called, instead adding a new option (`close_on_disconnect`) that can be set to `false`, allowing for manual reconnects. Also exposes the `close()` function so the connection can be cleaned manually if `close_on_disconnect` is set to `false`.~

~Also fixes a number of segfaults that can occur if the MQTT311 connection is closed. Now errors are thrown explaining that the MQTT311 connection has been closed and is no longer usable, rather than segfaulting.~

~Adding documentation for these new functions and tests to ensure functionality works as expected by default, and with the new option.~

Fixes segfaults that occur when you call `connect`, `disconnect`, and then `connect` again, or if you call `disconnect` and then try to perform any other operations (subscribe, unsubscribe, publish, etc). Also adjusts documentation a bit, and adds a couple tests to ensure the current behavior works as expected without segfaults.

_________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
