### PR TITLE
Decouple close from disconnect

### DIFF
--- a/lib/native/aws_iot.ts
+++ b/lib/native/aws_iot.ts
@@ -73,7 +73,8 @@ export class AwsIotMqttConnectionConfigBuilder {
             password: undefined,
             tls_ctx: undefined,
             reconnect_min_sec: DEFAULT_RECONNECT_MIN_SEC,
-            reconnect_max_sec: DEFAULT_RECONNECT_MAX_SEC
+            reconnect_max_sec: DEFAULT_RECONNECT_MAX_SEC,
+            close_on_disconnect: true
         };
         this.is_using_custom_authorizer = false
     }
@@ -454,6 +455,23 @@ export class AwsIotMqttConnectionConfigBuilder {
      */
     with_reconnect_min_sec(min_sec: number) {
         this.params.reconnect_min_sec = min_sec;
+        return this;
+    }
+
+    /**
+     * Sets whether calling disconnecting will trigger a cleanup of native resources associated with the MqttClientConnection
+     * automatically when the MqttClientConnection disconnect() function is called.
+     *
+     * **Defaults to true.** If set to false, you must manually call the MqttClientConnection close()
+     * function when you are done connection or native resources will leak.
+     *
+     * Note: **Once close() is called, whether automatically on disconnect or manually, it is not safe to invoke any
+     * further operations or functions on the MqttClientConnection.**
+     *
+     * @param close_on_disconnect whether the connection will automatically clean resources on disconnect()
+     */
+    with_close_on_disconnect(close_on_disconnect: boolean) {
+        this.params.close_on_disconnect = close_on_disconnect;
         return this;
     }
 


### PR DESCRIPTION
*Description of changes:*

A follow-up PR to #455. Split the closing of native resources out from `disconnect` so the MQTT311 connection can be disconnected and reconnected using `disconnect` and `connect` respectively. Also allows performing offline operations by calling `disconnect`, applying the operations, and then `connect` again.

The new functionality is introduced via a new builder option for the NodeJS MQTT311 builder, called `close_on_disconnect`. `close_on_disconnect` is set to `true` by default to stay fully backwards compatible. Also exposes the `close` function so the customer can call `close` when `close_on_disconnect` is false and they are no longer needing to use the connection. The workflow when `close_on_disconnect` is false is the same as the MQTT5 client.

Also adds a couple tests to ensure everything is working as expected and adjusts documentation.

_____________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
