### PR TITLE
Validate the input types in the main operations in MQTT311

### DIFF
--- a/lib/browser/mqtt.ts
+++ b/lib/browser/mqtt.ts
@@ -435,6 +435,17 @@ export class MqttClientConnection extends BufferedEventEmitter {
      * * For QoS 2, completes when PUBCOMP is received.
      */
     async publish(topic: string, payload: Payload, qos: QoS, retain: boolean = false): Promise<MqttRequest> {
+        // Skip payload since it can be several different types
+        if (typeof(topic) !== 'string') {
+            return Promise.reject("topic is not a string");
+        }
+        if (typeof(qos) !== 'number') {
+            return Promise.reject("qos is not a number");
+        }
+        if (typeof(retain) !== 'boolean') {
+            return Promise.reject('retain is not a boolean');
+        }
+
         let payload_data = normalize_payload(payload);
         return new Promise((resolve, reject) => {
             this.connection.publish(topic, payload_data, { qos: qos, retain: retain }, (error, packet) => {
@@ -472,6 +483,13 @@ export class MqttClientConnection extends BufferedEventEmitter {
      *          from the server or is rejected when an exception occurs.
      */
     async subscribe(topic: string, qos: QoS, on_message?: OnMessageCallback): Promise<MqttSubscribeRequest> {
+        if (typeof(topic) !== 'string') {
+            return Promise.reject("topic is not a string");
+        }
+        if (typeof(qos) !== 'number') {
+            return Promise.reject("qos is not a number");
+        }
+
         this.subscriptions.insert(topic, on_message);
         return new Promise((resolve, reject) => {
             this.connection.subscribe(topic, { qos: qos }, (error, packet) => {
@@ -494,6 +512,10 @@ export class MqttClientConnection extends BufferedEventEmitter {
      *          UNSUBACK is received from the server or is rejected when an exception occurs.
      */
     async unsubscribe(topic: string): Promise<MqttRequest> {
+        if (typeof(topic) !== 'string') {
+            return Promise.reject("topic is not a string");
+        }
+
         this.subscriptions.remove(topic);
         return new Promise((resolve, reject) => {
             this.connection.unsubscribe(topic, undefined, (error?: Error, packet?: mqtt.Packet) => {

--- a/lib/native/mqtt.ts
+++ b/lib/native/mqtt.ts
@@ -430,6 +430,17 @@ export class MqttClientConnection extends NativeResourceMixin(BufferedEventEmitt
      * * For QoS 2, completes when PUBCOMP is received.
      */
     async publish(topic: string, payload: Payload, qos: QoS, retain: boolean = false) {
+        // Skip payload since it can be several different types
+        if (typeof(topic) !== 'string') {
+            return Promise.reject("topic is not a string");
+        }
+        if (typeof(qos) !== 'number') {
+            return Promise.reject("qos is not a number");
+        }
+        if (typeof(retain) !== 'boolean') {
+            return Promise.reject("retain is not a boolean");
+        }
+
         return new Promise<MqttRequest>((resolve, reject) => {
             reject = this._reject(reject);
             try {
@@ -460,6 +471,13 @@ export class MqttClientConnection extends NativeResourceMixin(BufferedEventEmitt
      *          from the server or is rejected when an exception occurs.
      */
     async subscribe(topic: string, qos: QoS, on_message?: OnMessageCallback) {
+        if (typeof(topic) !== 'string') {
+            return Promise.reject("topic is not a string");
+        }
+        if (typeof(qos) !== 'number') {
+            return Promise.reject("qos is not a number");
+        }
+
         return new Promise<MqttSubscribeRequest>((resolve, reject) => {
             reject = this._reject(reject);
 
@@ -480,6 +498,10 @@ export class MqttClientConnection extends NativeResourceMixin(BufferedEventEmitt
      *          UNSUBACK is received from the server or is rejected when an exception occurs.
      */
     async unsubscribe(topic: string) {
+        if (typeof(topic) !== 'string') {
+            return Promise.reject("topic is not a string");
+        }
+
         return new Promise<MqttRequest>((resolve, reject) => {
             reject = this._reject(reject);
 


### PR DESCRIPTION
*Description of changes:*

Adds conditions to make sure the input data types passed in the main MQTT311 operations (publish, subscribe, unsubscribe) are the correct data types and, if they are not, returns an error stating the issue. While this is done automatically and not needed for Typescript, for pure Javascript it can be easy to accidentally pass the wrong type and, when this happens, the error returned doesn't make it completely clear what is going on. This PR makes it where if an incorrect datatype is passed, a rejected promise is returned.

____________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
