### PR TITLE
Hardcoded `napi_no_external_buffers_allowed` value for Node 21 and below

### DIFF
--- a/source/module.c
+++ b/source/module.c
@@ -50,8 +50,9 @@ AWS_STATIC_ASSERT(NAPI_VERSION >= 4);
 
 /* TODO:
  * Hardcoded enum value for `napi_no_external_buffers_allowed`.
- * The enum `napi_no_external_buffers_allowed` is introduced in node14.
- * Use it for external buffer related changes after bump to node 14 */
+ * The enum `napi_no_external_buffers_allowed` is introduced in node21 and backport
+ * to node 14.21.2, 16.19.0, 18.13.0.
+ * Use `napi_no_external_buffers_allowed` for external buffer related changes after bump to node 21 */
 #define NAPI_NO_EXTERNAL_BUFFER_ENUM_VALUE 22
 
 static bool s_tsfn_enabled = false;
@@ -873,7 +874,7 @@ const char *aws_napi_status_to_str(napi_status status) {
         case napi_bigint_expected:
             reason = "napi_bigint_expected";
             break;
-        case napi_no_external_buffers_allowed:
+        case NAPI_NO_EXTERNAL_BUFFER_ENUM_VALUE:
             reason = "napi_no_external_buffers_allowed";
             break;
     }
@@ -976,7 +977,7 @@ napi_status aws_napi_create_external_arraybuffer(
     napi_status external_buffer_status =
         napi_create_external_arraybuffer(env, external_data, byte_length, finalize_cb, finalize_hint, result);
 
-    if (external_buffer_status == napi_no_external_buffers_allowed) {
+    if (external_buffer_status == NAPI_NO_EXTERNAL_BUFFER_ENUM_VALUE) {
 
         // The external buffer is disabled, manually copy the external_data into Node
         void *napi_buf_data = NULL;


### PR DESCRIPTION
This reverts commit 0aa0feb63859b8f1f6bca1759249df1d74c15ef2.

*Issue #, if available:*

*Description of changes:*
The enum `napi_no_external_buffers_allowed` is introduced in node21 and backport to node 14.21.2, 16.19.0, 18.13.0.
(Details in : https://github.com/nodejs/node/pull/45181)
We hardcoded `napi_no_external_buffers_allowed` value until we upgrade to node21. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
