### PR TITLE
Fix "Cannot find module" for aws-crt-nodejs

### DIFF
--- a/lib/native/binding.js
+++ b/lib/native/binding.js
@@ -63,12 +63,14 @@ const search_paths = [
 ];
 
 let binding;
-for (const path of search_paths) {
-    if (existsSync(path + '.node')) {
-        binding = require(path);
+for (const p of search_paths) {
+    const target = p + '.node';
+    if (existsSync(target)) {
+        binding = require(target);
         break;
     }
 }
+
 
 if (binding == undefined) {
     throw new Error("AWS CRT binary not present in any of the following locations:\n\t" + search_paths.join('\n\t'));


### PR DESCRIPTION
*Description of changes:*
In `lib/native/bindings.js`, after successfully finding the aws-crt-nodejs native module, it drops the *.node* extension when calling require. That should be fine in a pure commonJs environment but dropping the extension breaks some ES-like runtime and build environments.

This PR includes the extension in the require call.

I don't see a test to update. (Consider adding some? There seem to be a lot of regressions in aws-sdk-js-v3 relating to aws-crt and signature-v4-crt. It would take a lot of work around test fixtures but perhaps worthwhile/justified?)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
