### PR TITLE
Fix IoT custom authorizer without token signature

### DIFF
--- a/lib/common/aws_iot_shared.ts
+++ b/lib/common/aws_iot_shared.ts
@@ -82,13 +82,10 @@ export function populate_username_string_with_custom_authorizer(
         username_string = add_to_username_parameter(username_string, input_authorizer, "x-amz-customauthorizer-name=");
     }
 
-    if (is_string_and_not_empty(input_signature) || is_string_and_not_empty(input_token_value) || is_string_and_not_empty(input_token_key_name)) {
-        if (!input_token_value || !input_token_key_name || !input_signature) {
+    if (is_string_and_not_empty(input_signature) && input_signature) {
+        if (!is_string_and_not_empty(input_token_value) || !is_string_and_not_empty(input_token_key_name)) {
             throw new Error("Signing-based custom authentication requires all token-related properties to be set");
         }
-    }
-
-    if (is_string_and_not_empty(input_signature) && input_signature) {
         username_string = add_to_username_parameter(username_string, input_signature, "x-amz-customauthorizer-signature=");
     }
 


### PR DESCRIPTION
*Issue #, if available:* #527

*Description of changes:*
Fixes the check when using a customizer to only require a `input_token_value` and `input_token_key_name` when an `input_signature` is provided.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
