### PR TITLE
Let mqtt.js auto-assign a client id 

### DIFF
--- a/lib/browser/mqtt5_utils.ts
+++ b/lib/browser/mqtt5_utils.ts
@@ -226,10 +226,10 @@ export function create_mqtt_js_client_config_from_crt_client_config(crtConfig : 
     }
 
     /*
-     * If you leave clientId undefined, mqtt-js will make up some weird thing for you, but the intent is that it
-     * should pass the empty client id so that the server assigns you one.
+     * MQTT.js treats an undefined client id specially, and we want it to do so, otherwise it will refuse
+     * to connect with clean session false
      */
-    utils.set_defined_property(mqttJsClientConfig, "clientId", crtConfig.connectProperties?.clientId ?? "");
+    utils.set_defined_property(mqttJsClientConfig, "clientId", crtConfig.connectProperties?.clientId);
     utils.set_defined_property(mqttJsClientConfig, "username", crtConfig.connectProperties?.username);
     utils.set_defined_property(mqttJsClientConfig, "password", crtConfig.connectProperties?.password);
     utils.set_defined_property(mqttJsClientConfig, "will", create_mqtt_js_will_from_crt_config(crtConfig.connectProperties));


### PR DESCRIPTION
rather than passing an empty client id and hanging the client when clean session is false

Per follow-ups on https://github.com/awslabs/aws-crt-nodejs/issues/536, MQTT.js will refuse to connect if client id is empty (using auto-assigned client id), and clean session is false.  By instead letting undefined by passed as the client id, mqtt.js will auto-assign a client id for us which lets us avoid a dependency on uuid.  


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
