### PR TITLE
Add polyfill for non-window browser contexts

### DIFF
--- a/lib/browser/polyfills.ts
+++ b/lib/browser/polyfills.ts
@@ -7,11 +7,15 @@ import buffer from 'buffer';
 import process from 'process';
 
 // Workaround to get mqtt-js working with Webpack 5
+
+if (self) {
+    (self as any).Buffer = buffer.Buffer;
+    (self as any).process = process;
+}
+
 if (window) {
-    (window as any).Buffer = buffer.Buffer;
-    (window as any).process = process;
     // NodeJS global shim workaround for Angular
     (window as any).global = window;
 }
 
-export {};
+export { };


### PR DESCRIPTION
*Description of changes:*
This PR updates the browser polyfill check to check for any browser-based global context through `self` instead of window.  It should enable `aws-crt-nodejs` to work in web and service worker contexts.

------
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
