### PR TITLE
explicitly depend on ws 8.17.1 for nested dependencies to use

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "yargs": "^17.7.2"
   },
   "dependencies": {
+    "ws": "^8.17.1", // @httptoolkit/websocket-stream nested ws * dependencies need to use this version or higher.
     "@aws-sdk/util-utf8-browser": "^3.259.0",
     "@httptoolkit/websocket-stream": "^6.0.1",
     "axios": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "yargs": "^17.7.2"
   },
   "dependencies": {
-    "ws": "^8.17.1", // @httptoolkit/websocket-stream nested ws * dependencies need to use this version or higher.
+    "ws": "^8.17.1",
     "@aws-sdk/util-utf8-browser": "^3.259.0",
     "@httptoolkit/websocket-stream": "^6.0.1",
     "axios": "^1.7.2",


### PR DESCRIPTION
Explicitly set ws dependency to v8.17.1 for nested dependencies to use.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
