### PR TITLE
Use node-16 for Mac OS arm64

### DIFF
--- a/builder.json
+++ b/builder.json
@@ -68,9 +68,9 @@
             "!imports": [ "node-14" ]
         },
         "macos": {
-            "_comment": "Mac OS (arm64) has only experimental support for Node v15 and earlier, so stick to Node v16, see Node v15 docs: https://github.com/nodejs/node/blob/v15.x/BUILDING.md#platform-list",
             "architectures": {
                 "arm64": {
+                    "_comment": "Mac OS (arm64) has only experimental support for Node v15 and earlier, so stick to Node v16, see Node v15 docs: https://github.com/nodejs/node/blob/v15.x/BUILDING.md#platform-list",
                     "!imports": [ "node-16" ]
                 }
             }

--- a/builder.json
+++ b/builder.json
@@ -66,6 +66,14 @@
         "al2012": {
             "!packages": [],
             "!imports": [ "node-14" ]
+        },
+        "macos": {
+            "_comment": "Mac OS (arm64) has only experimental support for Node v15 and earlier, so stick to Node v16, see Node v15 docs: https://github.com/nodejs/node/blob/v15.x/BUILDING.md#platform-list",
+            "architectures": {
+                "arm64": {
+                    "!imports": [ "node-16" ]
+                }
+            }
         }
     },
     "targets": {


### PR DESCRIPTION
*Issue #, if available:*

macos job currently fails in CI.

*Description of changes:*

Prior to Node v16, Mac OS arm64 has only experimental support (for example, see [Node v15 docs](https://github.com/nodejs/node/blob/v15.x/BUILDING.md#platform-list)). So, using node-16 for Mac OS arm64 job seems the right solution.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
