### PR TITLE
Indirect support for mqtt request response

### DIFF
--- a/lib/browser/mqtt_request_response/protocol_adapter_mock.ts
+++ b/lib/browser/mqtt_request_response/protocol_adapter_mock.ts
@@ -8,6 +8,7 @@ import * as protocol_adapter from "./protocol_adapter";
 import {BufferedEventEmitter} from "../../common/event";
 import {ICrtError} from "../../common/error";
 import * as subscription_manager from "./subscription_manager";
+import {IncomingPublishEventListener} from "./protocol_adapter";
 
 
 export interface ProtocolAdapterApiCall {
@@ -16,8 +17,12 @@ export interface ProtocolAdapterApiCall {
 }
 
 export interface MockProtocolAdapterOptions {
-    subscribeHandler?: (subscribeOptions: protocol_adapter.SubscribeOptions) => void,
-    unsubscribeHandler?: (unsubscribeOptions: protocol_adapter.UnsubscribeOptions) => void,
+    subscribeHandler?: (adapter: MockProtocolAdapter, subscribeOptions: protocol_adapter.SubscribeOptions, context?: any) => void,
+    subscribeHandlerContext?: any,
+    unsubscribeHandler?: (adapter: MockProtocolAdapter, unsubscribeOptions: protocol_adapter.UnsubscribeOptions, context?: any) => void,
+    unsubscribeHandlerContext?: any,
+    publishHandler?: (adapter: MockProtocolAdapter, publishOptions: protocol_adapter.PublishOptions, context?: any) => void,
+    publishHandlerContext?: any,
 }
 
 export class MockProtocolAdapter extends BufferedEventEmitter {
@@ -39,6 +44,10 @@ export class MockProtocolAdapter extends BufferedEventEmitter {
             methodName: "publish",
             args: publishOptions
         });
+
+        if (this.options && this.options.publishHandler) {
+            this.options.publishHandler(this, publishOptions, this.options.publishHandlerContext);
+        }
     }
 
     subscribe(subscribeOptions : protocol_adapter.SubscribeOptions) : void {
@@ -48,7 +57,7 @@ export class MockProtocolAdapter extends BufferedEventEmitter {
         });
 
         if (this.options && this.options.subscribeHandler) {
-            this.options.subscribeHandler(subscribeOptions);
+            this.options.subscribeHandler(this, subscribeOptions, this.options.subscribeHandlerContext);
         }
     }
 
@@ -59,7 +68,7 @@ export class MockProtocolAdapter extends BufferedEventEmitter {
         });
 
         if (this.options && this.options.unsubscribeHandler) {
-            this.options.unsubscribeHandler(unsubscribeOptions);
+            this.options.unsubscribeHandler(this, unsubscribeOptions,this.options.unsubscribeHandlerContext);
         }
     }
 
@@ -104,6 +113,7 @@ export class MockProtocolAdapter extends BufferedEventEmitter {
             event.retryable = retryable;
         }
 
+        // TODO - rework tests to pass with deferred event emission
         this.emit(protocol_adapter.ProtocolClientAdapter.SUBSCRIBE_COMPLETION, event);
     }
 
@@ -118,7 +128,29 @@ export class MockProtocolAdapter extends BufferedEventEmitter {
             event.retryable = retryable;
         }
 
+        // TODO - rework tests to pass with deferred event emission
         this.emit(protocol_adapter.ProtocolClientAdapter.UNSUBSCRIBE_COMPLETION, event);
+    }
+
+    completePublish(completionData: any, err?: ICrtError) : void {
+        let event : protocol_adapter.PublishCompletionEvent = {
+            completionData: completionData
+        };
+
+        if (err) {
+            event.err = err;
+        }
+
+        this.emit(protocol_adapter.ProtocolClientAdapter.PUBLISH_COMPLETION, event);
+    }
+
+    triggerIncomingPublish(topic: string, payload: ArrayBuffer) : void {
+        let event : protocol_adapter.IncomingPublishEvent = {
+            topic : topic,
+            payload: payload
+        };
+
+        this.emit(protocol_adapter.ProtocolClientAdapter.INCOMING_PUBLISH, event);
     }
 
     // Events
@@ -129,6 +161,8 @@ export class MockProtocolAdapter extends BufferedEventEmitter {
     on(event: 'unsubscribeCompletion', listener: protocol_adapter.UnsubscribeCompletionEventListener): this;
 
     on(event: 'connectionStatus', listener: protocol_adapter.ConnectionStatusEventListener): this;
+
+    on(event: 'incomingPublish', listener: IncomingPublishEventListener): this;
 
     on(event: string | symbol, listener: (...args: any[]) => void): this {
         super.on(event, listener);

--- a/lib/browser/mqtt_request_response/subscription_manager.ts
+++ b/lib/browser/mqtt_request_response/subscription_manager.ts
@@ -127,6 +127,23 @@ export enum AcquireSubscriptionResult {
     Failure,
 }
 
+export function acquireSubscriptionResultToString(result: AcquireSubscriptionResult) : string {
+    switch (result) {
+        case AcquireSubscriptionResult.Subscribed:
+            return "Subscribed";
+        case AcquireSubscriptionResult.Subscribing:
+            return "Subscribing";
+        case AcquireSubscriptionResult.Blocked:
+            return "Blocked";
+        case AcquireSubscriptionResult.NoCapacity:
+            return "NoCapacity";
+        case AcquireSubscriptionResult.Failure:
+            return "Failure";
+        default:
+            return "Unknown";
+    }
+}
+
 export interface SubscriptionManagerConfig {
     maxRequestResponseSubscriptions: number,
     maxStreamingSubscriptions: number,

--- a/lib/common/mqtt_request_response_internal.ts
+++ b/lib/common/mqtt_request_response_internal.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+/**
+ * @packageDocumentation
+ * @module mqtt_request_response
+ */
+
+export enum StreamingOperationState {
+    None,
+    Open,
+    Closed,
+}
+
+export enum RequestResponseClientState {
+    Ready,
+    Closed
+}

--- a/lib/common/mqtt_shared.ts
+++ b/lib/common/mqtt_shared.ts
@@ -45,3 +45,65 @@ export function normalize_payload(payload: any): Buffer | string {
 
 /** @internal */
 export const DEFAULT_KEEP_ALIVE : number = 1200;
+
+
+function isValidTopicInternal(topic: string, isFilter: boolean) : boolean {
+    if (topic.length === 0 || topic.length > 65535) {
+        return false;
+    }
+
+    let sawHash : boolean = false;
+    for (let segment of topic.split('/')) {
+        if (sawHash) {
+            return false;
+        }
+
+        if (segment.length === 0) {
+            continue;
+        }
+
+        if (segment.includes("+")) {
+            if (!isFilter) {
+                return false;
+            }
+
+            if (segment.length > 1) {
+                return false;
+            }
+        }
+
+        if (segment.includes("#")) {
+            if (!isFilter) {
+                return false;
+            }
+
+            if (segment.length > 1) {
+                return false;
+            }
+
+            sawHash = true;
+        }
+    }
+
+    return true;
+}
+
+export function isValidTopicFilter(topicFilter: any) : boolean {
+    if (typeof(topicFilter) !== 'string') {
+        return false;
+    }
+
+    let topicFilterAsString = topicFilter as string;
+
+    return isValidTopicInternal(topicFilterAsString, true);
+}
+
+export function isValidTopic(topic: any) : boolean {
+    if (typeof(topic) !== 'string') {
+        return false;
+    }
+
+    let topicAsString = topic as string;
+
+    return isValidTopicInternal(topicAsString, false);
+}

--- a/test/test_env.ts
+++ b/test/test_env.ts
@@ -108,8 +108,7 @@ export class AWS_IOT_ENV {
         return AWS_IOT_ENV.MQTT5_HOST !== "" &&
             AWS_IOT_ENV.MQTT5_REGION !== "" &&
             AWS_IOT_ENV.MQTT5_CRED_ACCESS_KEY !== "" &&
-            AWS_IOT_ENV.MQTT5_CRED_SECRET_ACCESS_KEY !== "" &&
-            AWS_IOT_ENV.MQTT5_CRED_SESSION_TOKEN !== "";
+            AWS_IOT_ENV.MQTT5_CRED_SECRET_ACCESS_KEY !== "";
     }
 
     public static mqtt5_is_valid_cognito() {


### PR DESCRIPTION
Some refactorings and supporting functionality needed for the request-response functionality of the MQTT request-response clients.

* Incoming publish support in the protocol adapter
* Mock protocol adapter extensions to support request-response testing
* Topic and topic filter validators that are ports of what we have in aws-c-mqtt

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
