### PR TITLE
bump pack size

### DIFF
--- a/continuous-delivery/pack.sh
+++ b/continuous-delivery/pack.sh
@@ -39,7 +39,7 @@ mkdir $UNZIP
 tar -xf aws-crt-$CURRENT_TAG.tgz -C $UNZIP
 PACK_FILE_SIZE_KB=$(du -sk $UNZIP | awk '{print $1}')
 echo "Current package size: ${PACK_FILE_SIZE_KB}"
-if expr $PACK_FILE_SIZE_KB \> "$((25000))" ; then
+if expr $PACK_FILE_SIZE_KB \> "$((26000))" ; then
     # the package size is too large, return -1
     echo "Package size is too large!"
     exit -1


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Release pipeline is failing with 
```
echo 'Current package size: 25736'
Current package size: 25736
+ expr 25736 '>' 25000
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
