### PR TITLE
Logger fallback to console.error if process._rawDebug is missing

### DIFF
--- a/source/logger.c
+++ b/source/logger.c
@@ -264,13 +264,13 @@ void s_threadsafe_log_create(struct aws_napi_logger_ctx *ctx, napi_env env) {
     /* process._rawDebug is specific to NodeJS and may not exist in
        other environments like Deno, fall back to console.error */
     if (rawdebug_type == napi_undefined) {
-       napi_value node_console = NULL;
-       AWS_NAPI_ENSURE(env, napi_get_named_property(env, node_global, "console", &node_console));
+        napi_value node_console = NULL;
+        AWS_NAPI_ENSURE(env, napi_get_named_property(env, node_global, "console", &node_console));
 
-       napi_value node_error = NULL;
-       AWS_NAPI_ENSURE(env, napi_get_named_property(env, node_console, "error", &node_error));
+        napi_value node_error = NULL;
+        AWS_NAPI_ENSURE(env, napi_get_named_property(env, node_console, "error", &node_error));
 
-       node_rawdebug = node_error;
+        node_rawdebug = node_error;
     }
 
     napi_value resource_name = NULL;

--- a/source/logger.c
+++ b/source/logger.c
@@ -258,6 +258,21 @@ void s_threadsafe_log_create(struct aws_napi_logger_ctx *ctx, napi_env env) {
     napi_value node_rawdebug = NULL;
     AWS_NAPI_ENSURE(env, napi_get_named_property(env, node_process, "_rawDebug", &node_rawdebug));
 
+    napi_valuetype rawdebug_type;
+    AWS_NAPI_ENSURE(env, napi_typeof(env, node_rawdebug, &rawdebug_type));
+
+    /* process._rawDebug is specific to NodeJS and may not exist in
+       other environments like Deno, fall back to console.error */
+    if (rawdebug_type == napi_undefined) {
+       napi_value node_console = NULL;
+       AWS_NAPI_ENSURE(env, napi_get_named_property(env, node_global, "console", &node_console));
+
+       napi_value node_error = NULL;
+       AWS_NAPI_ENSURE(env, napi_get_named_property(env, node_console, "error", &node_error));
+
+       node_rawdebug = node_error;
+    }
+
     napi_value resource_name = NULL;
     AWS_NAPI_ENSURE(env, napi_create_string_utf8(env, "aws_logger", 10, &resource_name));
 


### PR DESCRIPTION
Duplicate of https://github.com/awslabs/aws-crt-nodejs/pull/590.
 When running under Deno instead of NodeJS I get the following stack trace when the native extension is loaded:

```
N-API call failed: napi_create_threadsafe_function( env, node_rawdebug, NULL, resource_name, 0, 1, ctx, s_threadsafe_log_finalize, ctx, s_threadsafe_log_call, &ctx->log_drain)                                                                                                                                                                           
    @ /codebuild/output/src1849732470/src/aws-crt-nodejs/source/logger.c:277: napi_function_expected                                                   
Fatal error condition occurred in /codebuild/output/src1849732470/src/aws-crt-nodejs/source/logger.c:277: napi_create_threadsafe_function( env, node_rawdebug, NULL, resource
_name, 0, 1, ctx, s_threadsafe_log_finalize, ctx, s_threadsafe_log_call, &ctx->log_drain)                                                                                
Exiting Application
```

Deno does not provide `console._rawDebug` so fall back to `console.error` instead.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
