### PR TITLE
Fix memory leak during signing

### DIFF
--- a/source/http_connection.c
+++ b/source/http_connection.c
@@ -149,8 +149,11 @@ struct http_connection_binding {
 /* finalizer called when node cleans up this object */
 static void s_http_connection_from_manager_binding_finalize(napi_env env, void *finalize_data, void *finalize_hint) {
     (void)finalize_hint;
-    (void)env;
     struct http_connection_binding *binding = finalize_data;
+
+    if (binding->node_external != NULL) {
+        napi_delete_reference(env, binding->node_external);
+    }
 
     /* no release call, the http_client_connection_manager has already released it */
     aws_mem_release(binding->allocator, binding);

--- a/source/http_connection_manager.c
+++ b/source/http_connection_manager.c
@@ -27,8 +27,10 @@ struct aws_http_connection_manager *aws_napi_get_http_connection_manager(
 
 static void s_http_connection_manager_finalize(napi_env env, void *finalize_data, void *finalize_hint) {
     (void)finalize_hint;
-    (void)env;
     struct http_connection_manager_binding *binding = finalize_data;
+    if (binding->node_external != NULL) {
+        napi_delete_reference(env, binding->node_external);
+    }
     aws_mem_release(binding->allocator, binding);
 }
 

--- a/source/http_stream.c
+++ b/source/http_stream.c
@@ -74,7 +74,7 @@ static void s_on_response_call(napi_env env, napi_value on_response, void *conte
     }
 
     /* clean up the response buffer */
-    aws_http_message_destroy(binding->response);
+    aws_http_message_release(binding->response);
     binding->response = NULL;
 }
 


### PR DESCRIPTION
**Issue:** (internal ticket V1637484435)

When doing SigV4A signing from aws-sdk-js-v3, memory usage gradually increases due to memory leaks.

**Description of changes:**
Fix leak that occurred if headers were queried repeatedly.

**Future Work:**
All native unit tests should check that they aren't leaking memory. I spent a few hours trying to add such tests, but couldn't get it working in a reliable way. I didn't want this to hold back the fix, so leaving it for another day. See these blog posts for hints on various techniques NodeJS has used for leak testing through the years: https://joyeecheung.github.io/blog/2024/03/17/memory-leak-testing-v8-node-js-1/, https://joyeecheung.github.io/blog/2024/03/17/memory-leak-testing-v8-node-js-2/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
