### PR TITLE
Add topic argument to publish callback in request-response stream client

### DIFF
--- a/lib/browser/mqtt_request_response.ts
+++ b/lib/browser/mqtt_request_response.ts
@@ -808,6 +808,7 @@ export class RequestResponseClient extends BufferedEventEmitter implements mqtt_
 
             let streamingOperation = operation as StreamingOperation;
             streamingOperation.operation.triggerIncomingPublishEvent({
+                topic: event.topic,
                 payload: event.payload
             });
         }

--- a/lib/common/mqtt_request_response.ts
+++ b/lib/common/mqtt_request_response.ts
@@ -58,6 +58,11 @@ export interface SubscriptionStatusEvent {
 export interface IncomingPublishEvent {
 
     /**
+     * MQTT Topic that the response was received on.
+     */
+    topic: string
+
+    /**
      * The payload of the incoming message.
      */
     payload: StreamingPayload
@@ -235,4 +240,3 @@ export interface IRequestResponseClient {
      */
     submitRequest(requestOptions: RequestResponseOperationOptions): Promise<Response>;
 }
-

--- a/test/mqtt_request_response.ts
+++ b/test/mqtt_request_response.ts
@@ -467,6 +467,7 @@ export async function do_streaming_operation_incoming_publish_test(version: Prot
 
     let incoming_publish : mqtt_request_response.IncomingPublishEvent = (await publish_received_promise)[0];
 
+    expect(incoming_publish.topic).toEqual(topic_filter);
     expect(Buffer.from(incoming_publish.payload as ArrayBuffer)).toEqual(payload);
 
     stream.close();


### PR DESCRIPTION
Issue #, if available:
Service client might need a topic where a stream's publish message was received.

Description of changes:
Add a topic argument to incoming publish callback.

**NOTE**: In this PR, I put topic before payload, similarly to request client.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
