### PR TITLE
CD fix for Windows TLS 1.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,8 @@ set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "" SUFFIX ".node")
 target_include_directories(${PROJECT_NAME} PRIVATE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>
-        ${CMAKE_JS_INC})
+        ${CMAKE_JS_INC}
+        ${CMAKE_JS_INC}/node)
 
 aws_use_package(aws-c-http REQUIRED)
 aws_use_package(aws-c-mqtt REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,10 @@
 cmake_minimum_required(VERSION 3.9...3.31)
+
+if(DEFINED ENV{AWS_WINDOWS_SDK_VERSION} AND NOT "$ENV{AWS_WINDOWS_SDK_VERSION}" STREQUAL "")
+    set(CMAKE_SYSTEM_VERSION "$ENV{AWS_WINDOWS_SDK_VERSION}" CACHE STRING "Target Windows SDK Version" FORCE)
+    message(STATUS "Using AWS_WINDOWS_SDK_VERSION from environment: $ENV{AWS_WINDOWS_SDK_VERSION}")
+endif()
+
 project(aws-crt-nodejs C)
 option(BUILD_DEPS "Builds aws common runtime dependencies as part of build, only do this if you don't want to control your dependency chain." ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,8 +108,7 @@ set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "" SUFFIX ".node")
 target_include_directories(${PROJECT_NAME} PRIVATE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>
-        ${CMAKE_JS_INC}
-        ${CMAKE_JS_INC}/node)
+        ${CMAKE_JS_INC})
 
 aws_use_package(aws-c-http REQUIRED)
 aws_use_package(aws-c-mqtt REQUIRED)

--- a/continuous-delivery/build-binaries-win64.bat
+++ b/continuous-delivery/build-binaries-win64.bat
@@ -1,3 +1,5 @@
+set AWS_WINDOWS_SDK_VERSION=10.0.17763.0
+
 npm install || goto error
 
 :error


### PR DESCRIPTION
For building Windows on Jenkins with TLS 1.3 support, the Windows SDK version 10.0.17763.0 must be used for schannel.h to contain SCH_CREDENTIALS and TLS_PARAMETERS used for TLS 1.3.

The env AWS_WINDOWS_SDK_VERSION is set to 10.0.17763.0 in the windows cd .bat files. CMakeLists.txt has been modified to check for this env and if it exists, sets the CMAKE_SYSTEM_VERSION to use it. If it is not set, nothing different happens.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
