### PR TITLE
fix nodejs arm ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   linux-compat:
-    runs-on: ubuntu-22.04 # temporarily downgrade to old ubuntu until https://github.com/actions/runner-images/issues/11471 resolves
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -43,7 +43,7 @@ jobs:
     - name: Build ${{ env.PACKAGE_NAME }}
       run: |
         aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
-        docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+        docker run --privileged --rm tonistiigi/binfmt --install all
         ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ matrix.image }} build -p ${{ env.PACKAGE_NAME }}
 
   musl-linux:
@@ -62,7 +62,6 @@ jobs:
     - name: Build ${{ env.PACKAGE_NAME }}
       run: |
         aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
-        docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
         ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ matrix.image }} build -p ${{ env.PACKAGE_NAME }}
 
   linux-musl-armv8:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We rely on qemu to test aarch64 on x86-64 github runners.
Qemu had a bug where they had a bug with incorrectly mapping address space. That mostly worked fine until kernel patch that increased entropy in their address randomization. TLDR; qemu likes to segfault a lot against new kernels on our aarch64 test. Solution is to switch to a different github qemu user static image that forces a latest version of qemu, that has the bug fixed.
if you want to read more - https://github.com/tonistiigi/binfmt/issues/240


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
