### PR TITLE
Add required keepAliveIntervalSeconds in MQTT5 PubSub React sample

### DIFF
--- a/lib/common/mqtt5_packet.ts
+++ b/lib/common/mqtt5_packet.ts
@@ -875,7 +875,7 @@ export interface ConnectPacket extends IPacket {
      *
      * See [MQTT5 Keep Alive](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901045)
      */
-    keepAliveIntervalSeconds: number;
+    keepAliveIntervalSeconds: 30;
 
     /**
      * A unique string identifying the client to the server.  Used to restore session state between connections.

--- a/lib/common/mqtt5_packet.ts
+++ b/lib/common/mqtt5_packet.ts
@@ -875,7 +875,7 @@ export interface ConnectPacket extends IPacket {
      *
      * See [MQTT5 Keep Alive](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901045)
      */
-    keepAliveIntervalSeconds: 30;
+    keepAliveIntervalSeconds: 30; // This is required, not optional
 
     /**
      * A unique string identifying the client to the server.  Used to restore session state between connections.


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Added required keepAliveIntervalSeconds parameter in the MQTT5 PubSub React sample as it's a mandatory field according to: https://github.com/awslabs/aws-crt-nodejs/blame/main/lib/common/mqtt5_packet.ts#L878

Changes made:
- Added keepAliveIntervalSeconds: 30 to the connect packet configuration in PubSub React sample
- This parameter is required as per MQTT5 specification and cannot be optional

This fixes the TypeScript compilation error:
TS2345: Argument of type '{ clientId: string; }' is not assignable to parameter of type 'ConnectPacket'.
Property 'keepAliveIntervalSeconds' is missing in type '{ clientId: string; }' but required in type 'ConnectPacket'.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.