### PR TITLE
Support changes in req-resp operations

### DIFF
--- a/source/mqtt_request_response.c
+++ b/source/mqtt_request_response.c
@@ -1400,13 +1400,12 @@ done:
 }
 
 static void s_mqtt_streaming_operation_on_incoming_publish(
-    struct aws_byte_cursor payload,
-    struct aws_byte_cursor topic,
+    const struct aws_mqtt_request_response_publish_event *publish_event,
     void *user_data) {
     struct aws_request_response_streaming_operation_binding *binding = user_data;
 
     struct on_incoming_publish_user_data *incoming_publish_ud =
-        s_on_incoming_publish_user_data_new(binding, topic, payload);
+        s_on_incoming_publish_user_data_new(binding, publish_event->topic, publish_event->payload);
     if (incoming_publish_ud == NULL) {
         return;
     }

--- a/source/mqtt_request_response.c
+++ b/source/mqtt_request_response.c
@@ -484,20 +484,19 @@ done:
 }
 
 static void s_on_request_complete(
-    const struct aws_byte_cursor *response_topic,
-    const struct aws_byte_cursor *payload,
+    const struct aws_mqtt_rr_incoming_publish_event *publish_event,
     int error_code,
     void *user_data) {
 
     struct aws_napi_mqtt_request_binding *binding = user_data;
 
     if (error_code == AWS_ERROR_SUCCESS) {
-        AWS_FATAL_ASSERT(response_topic != NULL && payload != NULL);
+        AWS_FATAL_ASSERT(publish_event != NULL);
 
-        aws_byte_buf_init_copy_from_cursor(&binding->topic, binding->allocator, *response_topic);
+        aws_byte_buf_init_copy_from_cursor(&binding->topic, binding->allocator, publish_event->topic);
 
         binding->payload = aws_mem_calloc(binding->allocator, 1, sizeof(struct aws_byte_buf));
-        aws_byte_buf_init_copy_from_cursor(binding->payload, binding->allocator, *payload);
+        aws_byte_buf_init_copy_from_cursor(binding->payload, binding->allocator, publish_event->payload);
     } else {
         binding->error_code = error_code;
     }
@@ -1400,7 +1399,7 @@ done:
 }
 
 static void s_mqtt_streaming_operation_on_incoming_publish(
-    const struct aws_mqtt_request_response_publish_event *publish_event,
+    const struct aws_mqtt_rr_incoming_publish_event *publish_event,
     void *user_data) {
     struct aws_request_response_streaming_operation_binding *binding = user_data;
 


### PR DESCRIPTION
*Issue #, if available:*

The upstream PR https://github.com/awslabs/aws-c-mqtt/pull/389 changes API for the request-response operations. Because of that, we cannot release aws-c-mqtt, otherwise it might block other releases needed for other tasks. So, the purpose of this PR is just to unblock release of aws-c-mqtt breaking changes. Support for the new fields in request-response operations will be implemented in the future.

*Description of changes:*

Adjust signature of the incoming publish callback for the request response operations.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
