### PR TITLE
Build with Warning as Error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on:
+on: 
   push:
     branches-ignore:
       - 'main'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: 
+on:
   push:
     branches-ignore:
       - 'main'

--- a/builder.json
+++ b/builder.json
@@ -74,6 +74,20 @@
                     "!imports": [ "node-16" ]
                 }
             }
+        },
+        "windows": {
+            "!build_steps": [
+                [
+                    "node",
+                    "scripts/build.js",
+                    "-DAWS_WARNINGS_ARE_ERRORS=ON",
+                ],
+                [
+                    "npm",
+                    "install",
+                    "--unsafe-perm"
+                ]
+            ]
         }
     },
     "targets": {

--- a/builder.json
+++ b/builder.json
@@ -104,11 +104,6 @@
             "--unsafe-perm"
         ],
         [
-            "node",
-            "scripts/build.js",
-            "-DAWS_WARNINGS_ARE_ERRORS=ON"
-        ],
-        [
             "npm",
             "run-script",
             "tsc"

--- a/builder.json
+++ b/builder.json
@@ -80,7 +80,7 @@
                 [
                     "node",
                     "scripts/build.js",
-                    "-DAWS_WARNINGS_ARE_ERRORS=ON",
+                    "-DAWS_WARNINGS_ARE_ERRORS=ON"
                 ],
                 [
                     "npm",

--- a/builder.json
+++ b/builder.json
@@ -74,20 +74,6 @@
                     "!imports": [ "node-16" ]
                 }
             }
-        },
-        "windows": {
-            "!build_steps": [
-                [
-                    "node",
-                    "scripts/build.js",
-                    "-DAWS_WARNINGS_ARE_ERRORS=ON"
-                ],
-                [
-                    "npm",
-                    "install",
-                    "--unsafe-perm"
-                ]
-            ]
         }
     },
     "targets": {
@@ -107,6 +93,11 @@
         ]
     ],
     "build_steps": [
+        [
+            "node",
+            "scripts/build.js",
+            "-DAWS_WARNINGS_ARE_ERRORS=ON"
+        ],
         [
             "npm",
             "install",

--- a/source/mqtt_request_response.c
+++ b/source/mqtt_request_response.c
@@ -604,7 +604,7 @@ static int s_compute_request_response_storage_properties(
 
     // Step 3 - Go through all the subscription topic filters, response paths, and options fields and add up
     // the lengths of all the string and binary data fields.
-    for (uint32_t i = 0; i < subscription_filter_count; ++i) {
+    for (size_t i = 0; i < subscription_filter_count; ++i) {
         napi_value array_element;
         AWS_NAPI_CALL(env, napi_get_element(env, node_subscription_topic_filters, i, &array_element), {
             AWS_LOGF_ERROR(

--- a/source/mqtt_request_response.c
+++ b/source/mqtt_request_response.c
@@ -604,7 +604,7 @@ static int s_compute_request_response_storage_properties(
 
     // Step 3 - Go through all the subscription topic filters, response paths, and options fields and add up
     // the lengths of all the string and binary data fields.
-    for (size_t i = 0; i < subscription_filter_count; ++i) {
+    for (uint32_t i = 0; i < subscription_filter_count; ++i) {
         napi_value array_element;
         AWS_NAPI_CALL(env, napi_get_element(env, node_subscription_topic_filters, i, &array_element), {
             AWS_LOGF_ERROR(
@@ -626,7 +626,7 @@ static int s_compute_request_response_storage_properties(
         storage_properties->bytes_needed += filter_length;
     }
 
-    for (size_t i = 0; i < response_path_count; ++i) {
+    for (uint32_t i = 0; i < response_path_count; ++i) {
         napi_value array_element;
         AWS_NAPI_CALL(env, napi_get_element(env, node_response_paths, i, &array_element), {
             AWS_LOGF_ERROR(
@@ -813,7 +813,7 @@ static int s_initialize_request_storage_from_napi_options(
         return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
     }
 
-    for (size_t i = 0; i < storage_properties.subscription_topic_filter_count; ++i) {
+    for (uint32_t i = 0; i < storage_properties.subscription_topic_filter_count; ++i) {
         napi_value array_element;
         AWS_NAPI_CALL(env, napi_get_element(env, node_subscription_topic_filters, i, &array_element), {
             AWS_LOGF_ERROR(
@@ -849,7 +849,7 @@ static int s_initialize_request_storage_from_napi_options(
         return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
     }
 
-    for (size_t i = 0; i < storage_properties.response_path_count; ++i) {
+    for (uint32_t i = 0; i < storage_properties.response_path_count; ++i) {
         napi_value response_path_element;
         AWS_NAPI_CALL(env, napi_get_element(env, node_response_paths, i, &response_path_element), {
             AWS_LOGF_ERROR(

--- a/source/mqtt_request_response.c
+++ b/source/mqtt_request_response.c
@@ -604,7 +604,7 @@ static int s_compute_request_response_storage_properties(
 
     // Step 3 - Go through all the subscription topic filters, response paths, and options fields and add up
     // the lengths of all the string and binary data fields.
-    for (size_t i = 0; i < subscription_filter_count; ++i) {
+    for (uint32_t i = 0; i < subscription_filter_count; ++i) {
         napi_value array_element;
         AWS_NAPI_CALL(env, napi_get_element(env, node_subscription_topic_filters, i, &array_element), {
             AWS_LOGF_ERROR(


### PR DESCRIPTION
windows-vc14-x86 was reporting a conversion from `size_t` to `uint32_t` with a possible loss of data when used with `napi_get_element`. 

In CI, we previously ran `npm install` before `node scripts/build.js -DAWS_WARNINGS_ARE_ERRORS=ON`. So that the first step actually build the shared lib without warning as errors and the next step just picked the cached built artifacts instead of building the source code with warning as errors, which hide the warnings generated by compiler.

Move the build with warnings as errors before npm install to make sure it reports warnings as error correctly.

