### PR TITLE
Bump tar-fs from 2.1.2 to 2.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4241,9 +4241,9 @@
       }
     },
     "tar-fs": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.2.tgz",
-      "integrity": "sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
+      "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
       "dev": true,
       "requires": {
         "chownr": "^1.1.1",


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-crt-nodejs/pull/621

*Description of changes:*
- run `npm audit fix` and then `npm install --lockfile-version=1`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
