### PR TITLE
fix(browser): surface mqtt-js errors during CONNECT as CONNECTION_FAILURE

### DIFF
--- a/lib/browser/mqtt5.spec.ts
+++ b/lib/browser/mqtt5.spec.ts
@@ -201,6 +201,38 @@ test_utils.conditional_test(test_utils.ClientEnvironmentalConfig.hasValidSuccess
     }));
 });
 
+test('Connection Failure - mqtt-js error during CONNECT emits connectionFailure', async () => {
+    /*
+     * When mqtt-js rejects the password during CONNECT packet serialisation
+     * (e.g. Uint8Array instead of string|Buffer), the error must surface as a
+     * connectionFailure event rather than being silently swallowed.
+     *
+     * This test does not need a running MQTT broker because the failure
+     * occurs locally inside mqtt-js writeToStream before any data is sent.
+     */
+    let config: mqtt5.Mqtt5ClientConfig = {
+        hostName: "localhost",
+        port: 9999,
+        connectProperties: {
+            keepAliveIntervalSeconds: 1200,
+            username: "testuser",
+            // @ts-ignore — deliberately passing an invalid type to trigger the bug
+            password: new Uint8Array([116, 101, 115, 116]), // "test" as Uint8Array
+        },
+        websocketOptions: {
+            urlFactoryOptions: {
+                urlFactory: mqtt5.Mqtt5WebsocketUrlFactoryType.Ws,
+            },
+        },
+        connectTimeoutMs: 3000,
+    };
+
+    let client = new mqtt5.Mqtt5Client(config);
+
+    // @ts-ignore
+    await test_utils.testFailedConnection(client);
+});
+
 function testFailedClientConstruction(config: mqtt5.Mqtt5ClientConfig) {
     expect(() => {
         new mqtt5.Mqtt5Client(config);

--- a/lib/browser/mqtt5.ts
+++ b/lib/browser/mqtt5.ts
@@ -839,6 +839,21 @@ export class Mqtt5Client extends BufferedEventEmitter implements mqtt5.IMqtt5Cli
         setTimeout(() => {
             this.emit(Mqtt5Client.INFO, new CrtError(error));
         }, 0);
+
+        /*
+         * If the error occurs while we are still connecting (before the
+         * mqtt-js 'close' event fires), the underlying stream may never
+         * close on its own — for example, when mqtt-js rejects the
+         * password during CONNECT packet serialisation the WebSocket
+         * stays open but no MQTT frames are ever sent.
+         *
+         * Force-close the mqtt-js client so that the normal
+         * on_browser_close path fires and emits CONNECTION_FAILURE,
+         * which lets consumers (and the reconnection scheduler) react.
+         */
+        if (this.lifecycleEventState == Mqtt5ClientLifecycleEventState.Connecting) {
+            this.browserClient?.end(true);
+        }
     }
 
     private on_attempting_connect () {


### PR DESCRIPTION
## Summary

When the browser MQTT5 client encounters an error from mqtt-js during the `Connecting` lifecycle state, the error is silently swallowed:

1. `on_browser_client_error` stores the error in `lastError` and emits it on the `INFO` event
2. No `CONNECTION_FAILURE` event is ever emitted
3. The underlying WebSocket can remain open indefinitely with no MQTT frames sent
4. The connection hangs silently — consumers and the reconnection scheduler never learn about the failure

### Reproduction

One concrete way to trigger this: pass a `Uint8Array` as the password to `newWebsocketMqttBuilderWithCustomAuth`. The CRT types accept binary data, but the underlying mqtt-js v4 `writeToStream` rejects anything that isn't `string | Buffer` with `Error: Invalid password`. In the browser there is no native `Buffer`, so `Uint8Array instanceof Buffer` is always `false`.

The WebSocket handshake succeeds (HTTP 101), but mqtt-js fails to serialize the CONNECT packet and emits an `error` event. The CRT wrapper catches this in `on_browser_client_error`, stores it in `lastError`, and emits on `INFO` — but since no MQTT frames are sent, the server never closes the WebSocket, `on_browser_close` is never called, and `CONNECTION_FAILURE` is never emitted.

### Fix

When an error occurs while `lifecycleEventState == Connecting`, force-close the mqtt-js client so that the normal `on_browser_close` → `CONNECTION_FAILURE` path fires. This lets consumers and the reconnection scheduler react to the failure.

## Test plan

- [ ] Verify existing browser MQTT5 tests still pass
- [ ] Confirm that passing an invalid password type triggers `CONNECTION_FAILURE` instead of hanging
- [ ] Confirm the reconnection scheduler picks up the failure and retries

🤖 Generated with [Claude Code](https://claude.com/claude-code)