### PR TITLE
Support s2n-tls on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,6 +185,52 @@ jobs:
         python3 codebuild/macos_compatibility_check.py arm64
         python3 codebuild/macos_compatibility_check.py x64
 
+  macos-s2n:
+    runs-on: macos-14 # latest
+    env:
+      AWS_CRT_USE_NON_FIPS_TLS_13: 1
+    steps:
+    - uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ env.CRT_CI_ROLE }}
+        aws-region: ${{ env.AWS_DEFAULT_REGION }}
+    - name: Build ${{ env.PACKAGE_NAME }} + consumers
+      run: |
+        python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
+        chmod a+x builder
+        ./builder build -p ${{ env.PACKAGE_NAME }} --spec=downstream
+    - name: Check backward compatibility for Macos
+      run: |
+        cd aws-crt-nodejs
+        python3 codebuild/macos_compatibility_check.py arm64
+
+  macos-x64-s2n:
+    runs-on: macos-14-large # latest
+    env:
+      AWS_CRT_USE_NON_FIPS_TLS_13: 1
+    steps:
+    - uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ env.CRT_CI_ROLE }}
+        aws-region: ${{ env.AWS_DEFAULT_REGION }}
+    - name: Build ${{ env.PACKAGE_NAME }} + consumers
+      run: |
+        python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
+        chmod a+x builder
+        ./builder build -p ${{ env.PACKAGE_NAME }} --spec=downstream
+    # check that OSX can build arm64 binaries from an x64 machine (which happens during release)
+    - name: Cross-compile arm64
+      run: |
+        cd aws-crt-nodejs
+        node ./scripts/build --target-arch arm64 -DAWS_WARNINGS_ARE_ERRORS=ON
+        test `lipo dist/bin/darwin-arm64-cruntime/aws-crt-nodejs.node -archs` = "arm64"
+        test `lipo dist/bin/darwin-x64-cruntime/aws-crt-nodejs.node -archs` = "x86_64"
+    - name: Check backward compatibility for Macos
+      run: |
+        cd aws-crt-nodejs
+        python3 codebuild/macos_compatibility_check.py arm64
+        python3 codebuild/macos_compatibility_check.py x64
+
   # check that docs can still build
   check-docs:
     runs-on: ubuntu-24.04 # latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,7 +171,7 @@ jobs:
       run: |
         python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
         chmod a+x builder
-        ./builder build -p ${{ env.PACKAGE_NAME }} --spec=downstream
+        ./builder build -p ${{ env.PACKAGE_NAME }} --spec=downstream --cmake-extra=-DCMAKE_NO_SYSTEM_FROM_IMPORTED=ON
     # check that OSX can build arm64 binaries from an x64 machine (which happens during release)
     - name: Cross-compile arm64
       run: |
@@ -217,7 +217,7 @@ jobs:
       run: |
         python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
         chmod a+x builder
-        ./builder build -p ${{ env.PACKAGE_NAME }} --spec=downstream
+        ./builder build -p ${{ env.PACKAGE_NAME }} --spec=downstream --cmake-extra=-DCMAKE_NO_SYSTEM_FROM_IMPORTED=ON
     # check that OSX can build arm64 binaries from an x64 machine (which happens during release)
     - name: Cross-compile arm64
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,10 @@ jobs:
       with:
         role-to-assume: ${{ env.CRT_CI_ROLE }}
         aws-region: ${{ env.AWS_DEFAULT_REGION }}
+    # CMAKE_NO_SYSTEM_FROM_IMPORTED: on Intel Macs, Homebrew installs to /usr/local, which is in
+    # the default system header search path. Without this flag, s2n picks up Homebrew's OpenSSL
+    # headers instead of the bundled aws-lc headers.
+    # Not needed on ARM where Homebrew uses /opt/homebrew (not in default search paths).
     - name: Build ${{ env.PACKAGE_NAME }} + consumers
       run: |
         python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
@@ -213,6 +217,10 @@ jobs:
       with:
         role-to-assume: ${{ env.CRT_CI_ROLE }}
         aws-region: ${{ env.AWS_DEFAULT_REGION }}
+    # CMAKE_NO_SYSTEM_FROM_IMPORTED: on Intel Macs, Homebrew installs to /usr/local, which is in
+    # the default system header search path. Without this flag, s2n picks up Homebrew's OpenSSL
+    # headers instead of the bundled aws-lc headers.
+    # Not needed on ARM where Homebrew uses /opt/homebrew (not in default search paths).
     - name: Build ${{ env.PACKAGE_NAME }} + consumers
       run: |
         python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,10 @@ if (BUILD_DEPS)
     set(BUILD_TESTING OFF)
 
     add_subdirectory(crt/aws-c-common)
-    if (UNIX AND NOT APPLE)
+    # On Linux and BSD, we use S2N for TLS and AWS-LC crypto.
+    # On Windows, we use the default OS libraries.
+    # On Apple, we use the default OS libraries by default, but support S2N usage.
+    if (UNIX)
         include(AwsPrebuildDependency)
         # s2n-tls uses libcrypto during its configuration, so we need to prebuild aws-lc.
         aws_prebuild_dependency(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ if (BUILD_DEPS)
             CMAKE_ARGUMENTS
                 -DUNSAFE_TREAT_WARNINGS_AS_ERRORS=OFF
                 -DBUILD_TESTING=OFF
+                -DCMAKE_NO_SYSTEM_FROM_IMPORTED=ON
         )
     endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ if (BUILD_DEPS)
     add_subdirectory(crt/aws-c-common)
     # On Linux and BSD, we use S2N for TLS and AWS-LC crypto.
     # On Windows, we use the default OS libraries.
+    # Build s2n-tls and aws-lc on all Unix platforms except non-macOS Apple (iOS, tvOS).
     # On macOS (Darwin), both Secure Transport and s2n are built; the TLS backend
     # is selected at runtime via the AWS_CRT_USE_NON_FIPS_TLS_13 environment variable.
     if (UNIX AND (NOT APPLE OR CMAKE_SYSTEM_NAME STREQUAL "Darwin"))
@@ -46,6 +47,14 @@ if (BUILD_DEPS)
                 -DBUILD_LIBSSL=OFF
                 -DBUILD_TESTING=OFF
         )
+        # On Intel Macs, Homebrew installs to /usr/local which is in the default system header
+        # search path. Without CMAKE_NO_SYSTEM_FROM_IMPORTED, s2n picks up Homebrew's OpenSSL
+        # headers instead of the bundled aws-lc headers. Not needed on ARM (/opt/homebrew)
+        # or Linux.
+        set(S2N_EXTRA_CMAKE_ARGUMENTS "")
+        if (APPLE AND CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+            list(APPEND S2N_EXTRA_CMAKE_ARGUMENTS -DCMAKE_NO_SYSTEM_FROM_IMPORTED=ON)
+        endif()
         # prebuild s2n-tls.
         aws_prebuild_dependency(
             DEPENDENCY_NAME S2N
@@ -53,7 +62,7 @@ if (BUILD_DEPS)
             CMAKE_ARGUMENTS
                 -DUNSAFE_TREAT_WARNINGS_AS_ERRORS=OFF
                 -DBUILD_TESTING=OFF
-                -DCMAKE_NO_SYSTEM_FROM_IMPORTED=ON
+                ${S2N_EXTRA_CMAKE_ARGUMENTS}
         )
     endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ if (BUILD_DEPS)
     # On Windows, we use the default OS libraries.
     # On macOS (Darwin), both Secure Transport and s2n are built; the TLS backend
     # is selected at runtime via the AWS_CRT_USE_NON_FIPS_TLS_13 environment variable.
-    if (UNIX)
+    if (UNIX AND (NOT APPLE OR CMAKE_SYSTEM_NAME STREQUAL "Darwin"))
         include(AwsPrebuildDependency)
         # s2n-tls uses libcrypto during its configuration, so we need to prebuild aws-lc.
         aws_prebuild_dependency(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,8 @@ if (BUILD_DEPS)
     add_subdirectory(crt/aws-c-common)
     # On Linux and BSD, we use S2N for TLS and AWS-LC crypto.
     # On Windows, we use the default OS libraries.
-    # On Apple, we use the default OS libraries by default, but support S2N usage.
+    # On macOS (Darwin), both Secure Transport and s2n are built; the TLS backend
+    # is selected at runtime via the AWS_CRT_USE_NON_FIPS_TLS_13 environment variable.
     if (UNIX)
         include(AwsPrebuildDependency)
         # s2n-tls uses libcrypto during its configuration, so we need to prebuild aws-lc.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,19 @@ After building the package locally, use ```node ./scripts/build.js --debug``` to
 
 ## Mac-Only TLS Behavior
 
-Please note that on Mac, once a private key is used with a certificate, that certificate-key pair is imported into the Mac Keychain.  All subsequent uses of that certificate will use the stored private key and ignore anything passed in programmatically.  Beginning in v1.1.11, when a stored private key from the Keychain is used, the following will be logged at the "info" log level:
+On macOS, both Apple Secure Transport and s2n-tls are compiled into the binary. By default, Apple Secure Transport is used as the TLS backend. You can switch to s2n-tls at runtime by setting the `AWS_CRT_USE_NON_FIPS_TLS_13` environment variable.
+
+This variable has no effect on Linux (which always uses s2n-tls) or Windows (which always uses Schannel).
+
+| | Secure Transport (default) | s2n-tls (`AWS_CRT_USE_NON_FIPS_TLS_13=1`) |
+|---|---|---|
+| TLS versions | Up to TLS 1.2 | Up to TLS 1.3 |
+| FIPS compliance | Yes | No |
+| macOS Keychain integration | Yes (PKCS#12, system certs) | No |
+
+### Keychain Behavior (Secure Transport only)
+
+When using the default Secure Transport backend, once a private key is used with a certificate, that certificate-key pair is imported into the Mac Keychain.  All subsequent uses of that certificate will use the stored private key and ignore anything passed in programmatically.  Beginning in v1.1.11, when a stored private key from the Keychain is used, the following will be logged at the "info" log level:
 
 ```
 static: certificate has an existing certificate-key pair that was previously imported into the Keychain.  Using key from Keychain instead of the one provided.

--- a/lib/native/aws_iot.spec.ts
+++ b/lib/native/aws_iot.spec.ts
@@ -85,7 +85,7 @@ test_env.conditional_test(cRuntime !== CRuntimeType.MUSL && test_env.AWS_IOT_ENV
     })
 });
 
-test_env.conditional_test(test_env.AWS_IOT_ENV.mqtt311_is_valid_pkcs12())('Aws Iot Core PKCS12 connection', async () => {
+test_env.conditional_test(test_env.AWS_IOT_ENV.mqtt311_is_valid_pkcs12() && !(platform() === "darwin" && !!process.env.AWS_CRT_USE_NON_FIPS_TLS_13))('Aws Iot Core PKCS12 connection', async () => {
     await retry.networkTimeoutRetryWrapper( async () => {
         let builder = aws_iot_mqtt311.AwsIotMqttConnectionConfigBuilder.new_mtls_pkcs12_builder({
             pkcs12_file: test_env.AWS_IOT_ENV.MQTT311_PKCS12_FILE,
@@ -373,9 +373,9 @@ test_env.conditional_test(test_env.AWS_IOT_ENV.mqtt5_is_valid_mtls_rsa())("Mqtt3
 });
 
 test_env.conditional_test(test_env.AWS_IOT_ENV.mqtt5_is_valid_mtls_rsa())("Mqtt311 client builder per-platform conditional support of PQ default TlsCipherPreference", () => {
-    do_cipher_preference_test(TlsCipherPreference.PQ_Default, platform() === "linux");
+    do_cipher_preference_test(TlsCipherPreference.PQ_Default, platform() === "linux" || (platform() === "darwin" && !!process.env.AWS_CRT_USE_NON_FIPS_TLS_13));
 });
 
 test_env.conditional_test(test_env.AWS_IOT_ENV.mqtt5_is_valid_mtls_rsa())("Mqtt311 client builder per-platform conditional support of latest 1.2 policy TlsCipherPreference", () => {
-    do_cipher_preference_test(TlsCipherPreference.TLSv1_2_2025_07, platform() === "linux");
+    do_cipher_preference_test(TlsCipherPreference.TLSv1_2_2025_07, platform() === "linux" || (platform() === "darwin" && !!process.env.AWS_CRT_USE_NON_FIPS_TLS_13));
 });

--- a/lib/native/aws_iot.spec.ts
+++ b/lib/native/aws_iot.spec.ts
@@ -85,6 +85,7 @@ test_env.conditional_test(cRuntime !== CRuntimeType.MUSL && test_env.AWS_IOT_ENV
     })
 });
 
+// Skip when AWS_CRT_USE_NON_FIPS_TLS_13 is set: TLS backend on macOS switches from Secure Transport to s2n-tls, which doesn't support PKCS#12.
 test_env.conditional_test(test_env.AWS_IOT_ENV.mqtt311_is_valid_pkcs12() && !(platform() === "darwin" && !!process.env.AWS_CRT_USE_NON_FIPS_TLS_13))('Aws Iot Core PKCS12 connection', async () => {
     await retry.networkTimeoutRetryWrapper( async () => {
         let builder = aws_iot_mqtt311.AwsIotMqttConnectionConfigBuilder.new_mtls_pkcs12_builder({

--- a/lib/native/aws_iot_mqtt5.spec.ts
+++ b/lib/native/aws_iot_mqtt5.spec.ts
@@ -291,7 +291,7 @@ test_env.conditional_test(cRuntime !== CRuntimeType.MUSL && test_env.AWS_IOT_ENV
     })
 });
 
-test_env.conditional_test(test_env.AWS_IOT_ENV.mqtt5_is_valid_pkcs12())('Aws Iot Core PKCS12 - Connection Success', async () => {
+test_env.conditional_test(test_env.AWS_IOT_ENV.mqtt5_is_valid_pkcs12() && !(platform() === "darwin" && !!process.env.AWS_CRT_USE_NON_FIPS_TLS_13))('Aws Iot Core PKCS12 - Connection Success', async () => {
     await retry.networkTimeoutRetryWrapper( async () => {
         let builder = iot.AwsIotMqtt5ClientConfigBuilder.newDirectMqttBuilderWithMtlsFromPkcs12(
             test_env.AWS_IOT_ENV.MQTT5_HOST,
@@ -352,9 +352,9 @@ test_env.conditional_test(test_env.AWS_IOT_ENV.mqtt5_is_valid_mtls_rsa())("Mqtt5
 });
 
 test_env.conditional_test(test_env.AWS_IOT_ENV.mqtt5_is_valid_mtls_rsa())("Mqtt5 client builder per-platform conditional support of PQ default TlsCipherPreference", () => {
-    do_cipher_preference_test(TlsCipherPreference.PQ_Default, platform() === "linux");
+    do_cipher_preference_test(TlsCipherPreference.PQ_Default, platform() === "linux" || (platform() === "darwin" && !!process.env.AWS_CRT_USE_NON_FIPS_TLS_13));
 });
 
 test_env.conditional_test(test_env.AWS_IOT_ENV.mqtt5_is_valid_mtls_rsa())("Mqtt5 client builder per-platform conditional support of latest 1.2 policy TlsCipherPreference", () => {
-    do_cipher_preference_test(TlsCipherPreference.TLSv1_2_2025_07, platform() === "linux");
+    do_cipher_preference_test(TlsCipherPreference.TLSv1_2_2025_07, platform() === "linux" || (platform() === "darwin" && !!process.env.AWS_CRT_USE_NON_FIPS_TLS_13));
 });

--- a/lib/native/aws_iot_mqtt5.spec.ts
+++ b/lib/native/aws_iot_mqtt5.spec.ts
@@ -291,6 +291,7 @@ test_env.conditional_test(cRuntime !== CRuntimeType.MUSL && test_env.AWS_IOT_ENV
     })
 });
 
+// Skip when AWS_CRT_USE_NON_FIPS_TLS_13 is set: TLS backend on macOS switches from Secure Transport to s2n-tls, which doesn't support PKCS#12.
 test_env.conditional_test(test_env.AWS_IOT_ENV.mqtt5_is_valid_pkcs12() && !(platform() === "darwin" && !!process.env.AWS_CRT_USE_NON_FIPS_TLS_13))('Aws Iot Core PKCS12 - Connection Success', async () => {
     await retry.networkTimeoutRetryWrapper( async () => {
         let builder = iot.AwsIotMqtt5ClientConfigBuilder.newDirectMqttBuilderWithMtlsFromPkcs12(

--- a/lib/native/aws_iot_mqtt5.spec.ts
+++ b/lib/native/aws_iot_mqtt5.spec.ts
@@ -315,6 +315,18 @@ test_env.conditional_test(test_env.AWS_IOT_ENV.mqtt5_is_valid_windows_cert())('A
     })
 });
 
+// TLS 1.3 is supported on all platforms except macOS with Secure Transport (which only supports up to TLS 1.2).
+test_env.conditional_test(test_env.AWS_IOT_ENV.mqtt5_is_valid_tls13() && !(platform() === "darwin" && !process.env.AWS_CRT_USE_NON_FIPS_TLS_13))('Aws Iot Core TLS 1.3 - Connection Success', async () => {
+    await retry.networkTimeoutRetryWrapper( async () => {
+        let builder = iot.AwsIotMqtt5ClientConfigBuilder.newDirectMqttBuilderWithMtlsFromPath(
+            test_env.AWS_IOT_ENV.MQTT5_TLS13_HOST,
+            test_env.AWS_IOT_ENV.MQTT5_RSA_CERT,
+            test_env.AWS_IOT_ENV.MQTT5_RSA_KEY
+        );
+        await test_utils.testConnect(new mqtt5.Mqtt5Client(builder.build()));
+    })
+});
+
 function do_successful_cipher_preference_test(tls_cipher_preference: TlsCipherPreference) {
     let builder = iot.AwsIotMqtt5ClientConfigBuilder.newDirectMqttBuilderWithMtlsFromPath(
         test_env.AWS_IOT_ENV.MQTT5_HOST,

--- a/lib/native/io.spec.ts
+++ b/lib/native/io.spec.ts
@@ -80,10 +80,10 @@ test("Supports default TlsCipherPreference", () => {
 });
 
 test("Per-Platform PQ default TlsCipherPreference", () => {
-    do_cipher_preference_test(TlsCipherPreference.PQ_Default, platform() === "linux");
+    do_cipher_preference_test(TlsCipherPreference.PQ_Default, platform() === "linux" || (platform() === "darwin" && !!process.env.AWS_CRT_USE_NON_FIPS_TLS_13));
 });
 
 test("Per-Platform latest 1.2 policy TlsCipherPreference", () => {
-    do_cipher_preference_test(TlsCipherPreference.TLSv1_2_2025_07, platform() === "linux");
+    do_cipher_preference_test(TlsCipherPreference.TLSv1_2_2025_07, platform() === "linux" || (platform() === "darwin" && !!process.env.AWS_CRT_USE_NON_FIPS_TLS_13));
 });
 

--- a/lib/native/io.spec.ts
+++ b/lib/native/io.spec.ts
@@ -79,6 +79,7 @@ test("Supports default TlsCipherPreference", () => {
     do_cipher_preference_test(TlsCipherPreference.Default, true);
 });
 
+// These cipher policies require s2n-tls. On macOS they're only available when AWS_CRT_USE_NON_FIPS_TLS_13 switches the backend from Secure Transport to s2n.
 test("Per-Platform PQ default TlsCipherPreference", () => {
     do_cipher_preference_test(TlsCipherPreference.PQ_Default, platform() === "linux" || (platform() === "darwin" && !!process.env.AWS_CRT_USE_NON_FIPS_TLS_13));
 });

--- a/test/test_env.ts
+++ b/test/test_env.ts
@@ -12,6 +12,7 @@ export class AWS_IOT_ENV {
     // ====================
 
     public static MQTT5_HOST = process.env.AWS_TEST_MQTT5_IOT_CORE_HOST ?? "";
+    public static MQTT5_TLS13_HOST = process.env.AWS_TEST_MQTT5_IOT_CORE_TLS13_HOST ?? "";
     public static MQTT5_REGION = process.env.AWS_TEST_MQTT5_IOT_CORE_REGION ?? "";
 
     public static MQTT5_RSA_CERT = process.env.AWS_TEST_MQTT5_IOT_CORE_RSA_CERT ?? "";
@@ -125,6 +126,12 @@ export class AWS_IOT_ENV {
             AWS_IOT_ENV.MQTT5_X509_KEY !== "" &&
             AWS_IOT_ENV.MQTT5_X509_ROLE_ALIAS !== "" &&
             AWS_IOT_ENV.MQTT5_X509_THING_NAME !== "";
+    }
+
+    public static mqtt5_is_valid_tls13() {
+        return AWS_IOT_ENV.MQTT5_TLS13_HOST !== "" &&
+            AWS_IOT_ENV.MQTT5_RSA_CERT !== "" &&
+            AWS_IOT_ENV.MQTT5_RSA_KEY !== "";
     }
 
     // ====================


### PR DESCRIPTION
Add support for s2n-tls as a TLS backend on macOS.
Apple Secure Transport remains the default for FIPS compliance.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
