### PR TITLE
Update aws-crt-builder to v0.9.93

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
       - 'docs'
 
 env:
-  BUILDER_VERSION: v0.9.92
+  BUILDER_VERSION: v0.9.93
   BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-crt-nodejs


### PR DESCRIPTION
Update aws-crt-builder to v0.9.93.
- Add new env var for TLS 1.3 host.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
