### PR TITLE
Remove excess cmake flag from macOS-x64 CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,15 +167,11 @@ jobs:
       with:
         role-to-assume: ${{ env.CRT_CI_ROLE }}
         aws-region: ${{ env.AWS_DEFAULT_REGION }}
-    # CMAKE_NO_SYSTEM_FROM_IMPORTED: on Intel Macs, Homebrew installs to /usr/local, which is in
-    # the default system header search path. Without this flag, s2n picks up Homebrew's OpenSSL
-    # headers instead of the bundled aws-lc headers.
-    # Not needed on ARM where Homebrew uses /opt/homebrew (not in default search paths).
     - name: Build ${{ env.PACKAGE_NAME }} + consumers
       run: |
         python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
         chmod a+x builder
-        ./builder build -p ${{ env.PACKAGE_NAME }} --spec=downstream --cmake-extra=-DCMAKE_NO_SYSTEM_FROM_IMPORTED=ON
+        ./builder build -p ${{ env.PACKAGE_NAME }} --spec=downstream
     # check that OSX can build arm64 binaries from an x64 machine (which happens during release)
     - name: Cross-compile arm64
       run: |
@@ -217,15 +213,11 @@ jobs:
       with:
         role-to-assume: ${{ env.CRT_CI_ROLE }}
         aws-region: ${{ env.AWS_DEFAULT_REGION }}
-    # CMAKE_NO_SYSTEM_FROM_IMPORTED: on Intel Macs, Homebrew installs to /usr/local, which is in
-    # the default system header search path. Without this flag, s2n picks up Homebrew's OpenSSL
-    # headers instead of the bundled aws-lc headers.
-    # Not needed on ARM where Homebrew uses /opt/homebrew (not in default search paths).
     - name: Build ${{ env.PACKAGE_NAME }} + consumers
       run: |
         python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
         chmod a+x builder
-        ./builder build -p ${{ env.PACKAGE_NAME }} --spec=downstream --cmake-extra=-DCMAKE_NO_SYSTEM_FROM_IMPORTED=ON
+        ./builder build -p ${{ env.PACKAGE_NAME }} --spec=downstream
     # check that OSX can build arm64 binaries from an x64 machine (which happens during release)
     - name: Cross-compile arm64
       run: |


### PR DESCRIPTION
Remove an excess cmake option from macos-x64 CI jobs.
This option is set in CMakeLists.txt, which is more robust since it doesn't require passing it explicitly to build process.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
