### PR TITLE
Increase package size

### DIFF
--- a/continuous-delivery/pack.sh
+++ b/continuous-delivery/pack.sh
@@ -39,7 +39,7 @@ mkdir $UNZIP
 tar -xf aws-crt-$CURRENT_TAG.tgz -C $UNZIP
 PACK_FILE_SIZE_KB=$(du -sk $UNZIP | awk '{print $1}')
 echo "Current package size: ${PACK_FILE_SIZE_KB}"
-if expr $PACK_FILE_SIZE_KB \> "$((35000))" ; then
+if expr $PACK_FILE_SIZE_KB \> "$((43000))" ; then
     # the package size is too large, return -1
     echo "Package size is too large!"
     exit -1


### PR DESCRIPTION
Supporting s2n-tls on macOS increased the package size.

Before s2n-tls:

```
npm notice name:          aws-crt
npm notice version:       1.31.0
npm notice filename:      aws-crt-1.31.0.tgz
npm notice package size:  12.1 MB
npm notice unpacked size: 33.8 MB
```

After s2n-tls:

```
npm notice name:          aws-crt
npm notice version:       1.32.0
npm notice filename:      aws-crt-1.32.0.tgz
npm notice package size:  15.4 MB
npm notice unpacked size: 42.7 MB
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
