### PR TITLE
Update submodules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -821,7 +821,6 @@
       "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.5.2.tgz",
       "integrity": "sha512-mpT8LJJ4CMeeahobofYWIjFo0xonRS/HfxnVEPMPFSQdGUt1uHCnoPT7Zhb+sjDU2wz0oKV0OLUR0WzrHNgfeA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "jest-matcher-utils": "^27.0.0",
         "pretty-format": "^27.0.0"
@@ -1234,7 +1233,6 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.3.tgz",
       "integrity": "sha512-btwCFJVjI4YWDNfau8RhZ+B1Q/VLoUITrm3RlP6y1tYGWIOa+InuYiRGXUBXo8nA1qKmHMyLB/iVQg5TT4eFoA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "caniuse-lite": "^1.0.30001646",
         "electron-to-chromium": "^1.5.4",
@@ -1379,15 +1377,14 @@
       }
     },
     "cmake-js": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/cmake-js/-/cmake-js-7.3.0.tgz",
-      "integrity": "sha512-dXs2zq9WxrV87bpJ+WbnGKv8WUBXDw8blNiwNHoRe/it+ptscxhQHKB1SJXa1w+kocLMeP28Tk4/eTCezg4o+w==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/cmake-js/-/cmake-js-7.4.0.tgz",
+      "integrity": "sha512-Lw0JxEHrmk+qNj1n9W9d4IvkDdYTBn7l2BW6XmtLj7WPpIo2shvxUy+YokfjMxAAOELNonQwX3stkPhM5xSC2Q==",
       "dev": true,
       "requires": {
         "axios": "^1.12.2",
         "debug": "^4",
         "fs-extra": "^11.2.0",
-        "lodash.isplainobject": "^4.0.6",
         "memory-stream": "^1.0.0",
         "node-api-headers": "^1.1.0",
         "npmlog": "^6.0.2",
@@ -2571,7 +2568,6 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-27.5.1.tgz",
       "integrity": "sha512-Yn0mADZB89zTtjkPJEXwrac3LHudkQMR+Paqa8uxJHCBr9agxztUifWCyiYrjhMPBoUVBjyny0I7XH6ozDr7QQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@jest/core": "^27.5.1",
         "import-local": "^3.0.2",
@@ -3305,12 +3301,6 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
-    "lodash.isplainobject": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
-      "dev": true
-    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -3841,7 +3831,6 @@
       "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-3.3.0.tgz",
       "integrity": "sha512-23zNqRltZ1PPoK28uRefWJ/zKb5Jhnzbbwbpcna2o5+QMn17F0khq5s1bdH3vPlyj+J36pubccR8wiNA/VE0Vw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "debug": "^4.1.0",
         "extract-zip": "^2.0.0",
@@ -4579,8 +4568,7 @@
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "unbzip2-stream": {
       "version": "1.4.3",
@@ -4910,7 +4898,6 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
       "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-      "peer": true,
       "requires": {}
     },
     "xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@types/uuid": "^10.0.0",
     "@types/ws": "^7.4.7",
     "aws-sdk": "^2.1537.0",
-    "cmake-js": "^7.3.0",
+    "cmake-js": "^8.0.0",
     "https-proxy-agent": "^5.0.1",
     "jest": "^27.2.1",
     "jest-puppeteer": "^5.0.4",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@types/uuid": "^10.0.0",
     "@types/ws": "^7.4.7",
     "aws-sdk": "^2.1537.0",
-    "cmake-js": "^8.0.0",
+    "cmake-js": "^7.4.0",
     "https-proxy-agent": "^5.0.1",
     "jest": "^27.2.1",
     "jest-puppeteer": "^5.0.4",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Bump sdkutils to get https://github.com/awslabs/aws-c-sdkutils/pull/65
Bumped cmake-js 7.3.0 --> 7.4.0 as a fix for failing windows CIs. (https://github.com/cmake-js/cmake-js/issues/352)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
