### PR TITLE
noCertificateRevocation option binding

### DIFF
--- a/lib/native/binding.d.ts
+++ b/lib/native/binding.d.ts
@@ -76,6 +76,7 @@ export function io_tls_ctx_new(
     windows_cert_store_path?: StringLike,
     tls_cipher_policy?: number,
     verify_peer?: boolean,
+    no_certificate_revocation?: boolean,
 ): NativeHandle;
 /* wraps aws_tls_connection_options #TODO: Wrap with ClassBinder */
 /** @internal */

--- a/lib/native/io.ts
+++ b/lib/native/io.ts
@@ -254,6 +254,21 @@ export class TlsContextOptions {
     public verify_peer: boolean = true;
 
     /**
+     * Set to true to disable certificate revocation checking during TLS negotiation.
+     * 
+     * On Windows (SChannel), this prevents the TLS handshake from making outbound network calls
+     * to CRL/OCSP revocation endpoints, which can block for minutes when the endpoints are unreachable
+     * (e.g., in private subnets without internet access).
+     *
+     * On Linux (s2n), this disables validation of OCSP stapled responses provided by the server.
+     *
+     * On Apple platforms, this is a no-op as revocation checking is not enabled by default.
+     * 
+     * Default is false (revocation checking enabled where available).
+     */
+    public no_certificate_revocation: boolean = false;
+
+    /**
      * Overrides the default system trust store.
      * @param ca_dirpath - Only used on Unix-style systems where all trust anchors are
      * stored in a directory (e.g. /etc/ssl/certs).
@@ -480,7 +495,8 @@ export abstract class TlsContext extends NativeResource {
             ctx_opt.pkcs11_options,
             ctx_opt.windows_cert_store_path,
             ctx_opt.tls_cipher_preference,
-            ctx_opt.verify_peer));
+            ctx_opt.verify_peer,
+            ctx_opt.no_certificate_revocation));
     }
 }
 

--- a/source/io.c
+++ b/source/io.c
@@ -372,7 +372,7 @@ napi_value aws_napi_io_tls_ctx_new(napi_env env, napi_callback_info info) {
     napi_status status = napi_ok;
     (void)status;
 
-    napi_value node_args[15];
+    napi_value node_args[16];
     size_t num_args = AWS_ARRAY_SIZE(node_args);
     napi_value *arg = &node_args[0];
     if (napi_ok != napi_get_cb_info(env, info, &num_args, node_args, NULL, NULL)) {
@@ -688,6 +688,19 @@ napi_value aws_napi_io_tls_ctx_new(napi_env env, napi_callback_info info) {
 
     aws_tls_ctx_options_set_verify_peer(&ctx_options, verify_peer);
     aws_tls_ctx_options_set_tls_cipher_preference(&ctx_options, tls_cipher_preferences);
+
+    bool no_certificate_revocation = false;
+    napi_value node_no_cert_revocation = *arg++;
+    if (!aws_napi_is_null_or_undefined(env, node_no_cert_revocation)) {
+        napi_value node_bool;
+        if (napi_ok != napi_coerce_to_bool(env, node_no_cert_revocation, &node_bool)) {
+            napi_throw_type_error(env, NULL, "no_certificate_revocation must be a boolean");
+            goto cleanup;
+        }
+        status = napi_get_value_bool(env, node_bool, &no_certificate_revocation);
+        AWS_FATAL_ASSERT(status == napi_ok);
+    }
+    ctx_options.no_certificate_revocation = no_certificate_revocation;
 
     struct aws_tls_ctx *tls_ctx = aws_tls_client_ctx_new(alloc, &ctx_options);
     if (!tls_ctx) {


### PR DESCRIPTION
Bind the tls option to disable certificate revocation checks.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
