### PR TITLE
fix(ci): Remove PPA dependency to fix CodeBuild network failures

### DIFF
--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -2,28 +2,25 @@ version: 0.2
 env:
   shell: bash
   variables:
-    BUILDER_VERSION: v0.9.53
-    BUILDER_SOURCE: releases
     BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
-    PACKAGE_NAME: aws-crt-cpp
+    PACKAGE_NAME: aws-crt-nodejs
 phases:
   install:
     commands:
-      - sudo add-apt-repository ppa:ubuntu-toolchain-r/test
       - sudo apt-get update -y
-      - sudo apt-get install gcc-7 cmake ninja-build python3 python3-pip -y
+      - sudo apt-get install cmake ninja-build python3 python3-pip -y
   pre_build:
     commands:
-      - export CC=gcc-7
       - export AWS_CRT_MEMORY_TRACING=2
   build:
     commands:
       - echo Build started on `date`
       - git submodule update --init
-      # Build using builder, which will also run tests
+      - export BUILDER_VERSION=$(cat .github/workflows/ci.yml | grep 'BUILDER_VERSION:' | sed 's/\s*BUILDER_VERSION:\s*\(.*\)/\1/')
+      - export BUILDER_SOURCE=$(cat .github/workflows/ci.yml | grep 'BUILDER_SOURCE:' | sed 's/\s*BUILDER_SOURCE:\s*\(.*\)/\1/')
+      - echo "Using builder version='${BUILDER_VERSION}' source='${BUILDER_SOURCE}'"
       - python3 -c "from urllib.request import urlretrieve; urlretrieve('$BUILDER_HOST/$BUILDER_SOURCE/$BUILDER_VERSION/builder.pyz?run=$CODEBUILD_BUILD_ID', 'builder.pyz')"
       - python3 builder.pyz build --project aws-crt-nodejs downstream
   post_build:
     commands:
       - echo Build completed on `date`
-


### PR DESCRIPTION
*Issue*
  The aws-crt-nodejs-integration-tests CodeBuild job intermittently fails during INSTALL phase:
   Error: retrieving gpg key timed out.
  Error reading https://launchpad.net/api/1.0/~ubuntu-toolchain-r/ppas: [Errno 104] Connection 

**Root Cause: **
  The buildspec calls `add-apt-repository ppa:ubuntu-toolchain-r/test` which requires an outbound HTTPS call to launchpad.net. CodeBuild's network cannot reliably reach Launchpad, causing timeouts and connection resets.
  
  The PPA was only needed to install `gcc-7`, which is not in Ubuntu 20.04's default repos. However, gcc-7 is not required since the image already has gcc-9 from build-essential.

*Description of changes:*
  - Remove `add-apt-repository ppa:ubuntu-toolchain-r/test` (root cause of failure)
  - Remove `gcc-7` install and export CC=gcc-7 (system gcc-9 is sufficient)
  - Read `BUILDER_VERSION/BUILDER_SOURCE` dynamically from ci.yml instead of hardcoding
  - Fix PACKAGE_NAME from a`ws-crt-cpp `to `aws-crt-nodejs`.

**Verification:**
- Compared with aws-crt-java, aws-crt-swift, aws-crt-python — none use the PPA
- Confirmed aws/codebuild/standard:5.0 (Ubuntu 20.04) has gcc-9 pre-installed via build-essential Reference: [default](https://linuxize.com/post/how-to-install-gcc-on-ubuntu-20-04/)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
