### PR TITLE
Add test for auto-PUBACK on QoS 1 publish received

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
       - 'docs'
 
 env:
-  BUILDER_VERSION: v0.9.93
+  BUILDER_VERSION: v0.9.96
   BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-crt-nodejs

--- a/lib/native/mqtt5.spec.ts
+++ b/lib/native/mqtt5.spec.ts
@@ -661,6 +661,19 @@ test_utils.conditional_test(test_utils.ClientEnvironmentalConfig.hasIotCoreEnvir
     })
 });
 
+test_utils.conditional_test(test_utils.ClientEnvironmentalConfig.hasIotCoreEnvironment())('Auto publish acknowledgement - no duplicate delivery', async() =>{
+    // Verify client sends PUBACK automatically when acquireHandle() is not called. Confirmed by no re-delivery.
+    await retry.networkTimeoutRetryWrapper( async () => {
+        let topic: string = `test-${uuid()}`;
+        let testPayload: Buffer = Buffer.from("hello", "utf-8");
+
+        let config: mqtt5.Mqtt5ClientConfig = createDirectIotCoreClientConfig();
+        let client: mqtt5.Mqtt5Client = new mqtt5.Mqtt5Client(config);
+
+        await test_utils.subPubAutoPubackNoDuplicateTest(client, topic, testPayload);
+    })
+});
+
 test_utils.conditional_test(test_utils.ClientEnvironmentalConfig.hasIotCoreEnvironment())('Will test', async () => {
     await retry.networkTimeoutRetryWrapper( async () => {
         let willPayload: Buffer = Buffer.from("ToMyChildrenIBequeathNothing", "utf-8");

--- a/test/mqtt5.ts
+++ b/test/mqtt5.ts
@@ -655,6 +655,60 @@ export async function subPubAcquireInvokeControlTest(client: mqtt5.Mqtt5Client, 
     client.close();
 }
 
+export async function subPubAutoPubackNoDuplicateTest(client: mqtt5.Mqtt5Client, topic: string, testPayload: mqtt5.Payload) {
+    let connectionSuccess = once(client, mqtt5.Mqtt5Client.CONNECTION_SUCCESS);
+    let stopped = once(client, mqtt5.Mqtt5Client.STOPPED);
+
+    client.start();
+
+    await connectionSuccess;
+
+    await client.subscribe({
+        subscriptions: [
+            { qos : mqtt5.QoS.AtLeastOnce, topicFilter: topic }
+        ]
+    });
+
+    // Verify client sends PUBACK automatically. We do NOT call acquireHandle().
+    let unexpectedRedelivery: boolean = false;
+    let firstMessageReceived: boolean = false;
+
+    let firstMessagePromise = new Promise<void>((resolve) => {
+        client.on('messageReceived', (eventData: mqtt5.MessageReceivedEvent) => {
+            if (!firstMessageReceived) {
+                firstMessageReceived = true;
+                // Intentionally do NOT call acquireHandle(), let auto-PUBACK happen
+                resolve();
+            } else {
+                // Any subsequent message is an unexpected re-delivery
+                unexpectedRedelivery = true;
+            }
+        });
+    });
+
+    await client.publish({
+        topicName: topic,
+        qos: mqtt5.QoS.AtLeastOnce,
+        payload: testPayload
+    });
+
+    await firstMessagePromise;
+
+    // Wait 35 seconds to confirm the broker does not re-deliver the message
+    await new Promise(resolve => setTimeout(resolve, 35000));
+
+    expect(unexpectedRedelivery).toEqual(false);
+
+    await client.unsubscribe({
+        topicFilters: [ topic ]
+    });
+
+    client.stop();
+    await stopped;
+
+    client.close();
+}
+
 export async function willTest(publisher: mqtt5.Mqtt5Client, subscriber: mqtt5.Mqtt5Client, willTopic: string) {
     let publisherConnected = once(publisher, mqtt5.Mqtt5Client.CONNECTION_SUCCESS);
     let publisherStopped = once(publisher, mqtt5.Mqtt5Client.STOPPED);


### PR DESCRIPTION
Verify that the client sends PUBACK automatically when acquireHandle() is not called.
Confirmed by the absence of broker re-delivery.

Bump aws-crt-builder to v0.9.96.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
