### PR TITLE
FIx(ci): crash due to unhandled Promise 

### DIFF
--- a/lib/browser/aws_iot.spec.ts
+++ b/lib/browser/aws_iot.spec.ts
@@ -150,7 +150,7 @@ test_env.conditional_test(test_env.AWS_IOT_ENV.mqtt311_is_valid_custom_auth_sign
 
         const connectionFailure = once(connection, "connection_failure")
         try {
-            connection.connect();
+            await connection.connect();
         } catch (error) {
             // Skip - this is expected because we are intentionally using a bad password
         }

--- a/samples/browser/pub_sub/index.ts
+++ b/samples/browser/pub_sub/index.ts
@@ -90,7 +90,9 @@ async function connect_websocket(provider: auth.CredentialsProvider) {
             reject(error);
         });
         log('connect...');
-        connection.connect();
+        connection.connect().catch((error) => {
+            reject(error);
+        });
     });
 
 }
@@ -98,7 +100,7 @@ async function connect_websocket(provider: auth.CredentialsProvider) {
 async function main() {
     /** Set up the credentialsProvider */
     const provider = new AWSCognitoCredentialsProvider({
-            IdentityPoolId: Config.AWS_COGNITO_IDENTITY_POOL_ID, 
+            IdentityPoolId: Config.AWS_COGNITO_IDENTITY_POOL_ID,
             Region: Config.AWS_REGION});
     /** Make sure the credential provider fetched before setup the connection */
     await provider.refreshCredentials();
@@ -112,7 +114,7 @@ async function main() {
             const decoder = new TextDecoder('utf8');
             let message = decoder.decode(new Uint8Array(payload));
             log(`Message received: topic=${topic} message=${message}`);
-            /** The sample is used to demo long-running web service. 
+            /** The sample is used to demo long-running web service.
              * Uncomment the following line to see how disconnect behaves.*/
             // connection.disconnect();
         })


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- An unhandled promise created a warning instead of failure due to `Node 14` default behavior that closed the socket silently

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
