### PR TITLE
Increase pacakge size

### DIFF
--- a/continuous-delivery/pack.sh
+++ b/continuous-delivery/pack.sh
@@ -39,7 +39,7 @@ mkdir $UNZIP
 tar -xf aws-crt-$CURRENT_TAG.tgz -C $UNZIP
 PACK_FILE_SIZE_KB=$(du -sk $UNZIP | awk '{print $1}')
 echo "Current package size: ${PACK_FILE_SIZE_KB}"
-if expr $PACK_FILE_SIZE_KB \> "$((43000))" ; then
+if expr $PACK_FILE_SIZE_KB \> "$((45000))" ; then
     # the package size is too large, return -1
     echo "Package size is too large!"
     exit -1

--- a/continuous-delivery/pack.sh
+++ b/continuous-delivery/pack.sh
@@ -35,13 +35,20 @@ cp aws-crt-*.tgz ..
 # Check unzip npm package size
 cd ..
 UNZIP="unzip_pack"
+
+# NPM does not have an hard limit for the package size, however, the Node.js CLI memory limits 
+# create an effective maximum threshold. Reference to https://github.com/npm/npm/issues/12750. 
+# The thread is old, while I did not find any update regards to the size limit. For now, using 
+# 100 MB size limit as a safe threadhold.
+NPM_FILE_SIZE_LIMIT_KB=$((100*1024))
+
 mkdir $UNZIP
 tar -xf aws-crt-$CURRENT_TAG.tgz -C $UNZIP
 PACK_FILE_SIZE_KB=$(du -sk $UNZIP | awk '{print $1}')
 echo "Current package size: ${PACK_FILE_SIZE_KB}"
-if expr $PACK_FILE_SIZE_KB \> "$((45000))" ; then
-    # the package size is too large, return -1
+if expr $PACK_FILE_SIZE_KB \> $NPM_FILE_SIZE_LIMIT_KB ; then
+    # the package size is too large
     echo "Package size is too large!"
-    exit -1
+    exit 1
 fi
 exit 0


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
To prevent the size validation from blocking the CD pipeline, we updated the CD size validation. Instead of matching the current exact size, set the limit to a larger NPM package size. This acts validate against exceeding NPM's upload limit without being overly restrictive in CD, as CI already handles the size detection on each platform. 
NPM didn't have an hard limit for the package size, however, the Node.js CLI memory limits create an effective maximum threshold. (https://github.com/npm/npm/issues/12750 The thread is a little old, while I didn't find any update regards to the size limit.), so use 100 MB size limit as a safe threadhold.

The package size is increased from:
```
npm notice === Tarball Details ===
--
npm notice name:          aws-crt
npm notice version:       1.32.3
npm notice filename:      aws-crt-1.32.3.tgz
npm notice package size:  15.5 MB
npm notice unpacked size: 43.1 MB
```
to

```
npm notice === Tarball Details === 
npm notice name:          aws-crt                                 
npm notice version:       1.33.0                                  
npm notice filename:      aws-crt-1.33.0.tgz                      
npm notice package size:  15.7 MB                                 
npm notice unpacked size: 44.3 MB                               
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
