### PR TITLE
Preserve Literal types for event names constants

### DIFF
--- a/lib/browser/http.ts
+++ b/lib/browser/http.ts
@@ -273,21 +273,21 @@ export class HttpClientConnection extends BufferedEventEmitter {
      *
      * @event
      */
-    static CONNECT = 'connect';
+    static CONNECT : 'connect' = 'connect';
 
     /**
      * Emitted when an error occurs on the connection
      *
      * @event
      */
-    static ERROR = 'error';
+    static ERROR : 'error' = 'error';
 
     /**
      * Emitted when the connection has completed
      *
      * @event
      */
-    static CLOSE = 'close';
+    static CLOSE : 'close' = 'close';
 
     on(event: 'connect', listener: HttpClientConnectionConnected): this;
 
@@ -408,28 +408,28 @@ export class HttpClientStream extends BufferedEventEmitter {
      *
      * @event
      */
-    static RESPONSE = 'response';
+    static RESPONSE : 'response' = 'response';
 
     /**
      * Emitted when http response data is available.
      *
      * @event
      */
-    static DATA = 'data';
+    static DATA : 'data' = 'data';
 
     /**
      * Emitted when an error occurs in stream processing
      *
      * @event
      */
-    static ERROR = 'error';
+    static ERROR : 'error' = 'error';
 
     /**
      * Emitted when the stream has completed
      *
      * @event
      */
-    static END = 'end';
+    static END : 'end' = 'end';
 
     on(event: 'response', listener: HttpStreamResponse): this;
 

--- a/lib/browser/mqtt.ts
+++ b/lib/browser/mqtt.ts
@@ -334,14 +334,14 @@ export class MqttClientConnection extends BufferedEventEmitter {
      *
      * @event
      */
-    static CONNECT = 'connect';
+    static CONNECT : 'connect' = 'connect';
 
     /**
      * Emitted when connection has disconnected successfully.
      *
      * @event
      */
-    static DISCONNECT = 'disconnect';
+    static DISCONNECT : 'disconnect' = 'disconnect';
 
     /**
      * Emitted when an error occurs.  The error will contain the error
@@ -349,7 +349,7 @@ export class MqttClientConnection extends BufferedEventEmitter {
      *
      * @event
      */
-    static ERROR = 'error';
+    static ERROR : 'error' = 'error';
 
     /**
      * Emitted when the connection is dropped unexpectedly. The error will contain the error
@@ -357,21 +357,21 @@ export class MqttClientConnection extends BufferedEventEmitter {
      *
      * @event
      */
-    static INTERRUPT = 'interrupt';
+    static INTERRUPT : 'interrupt' = 'interrupt';
 
     /**
      * Emitted when the connection reconnects (after an interrupt). Only triggers on connections after the initial one.
      *
      * @event
      */
-    static RESUME = 'resume';
+    static RESUME : 'resume' = 'resume';
 
     /**
      * Emitted when any MQTT publish message arrives.
      *
      * @event
      */
-    static MESSAGE = 'message';
+    static MESSAGE : 'message' = 'message';
 
     /**
      * Emitted on every successful connect and reconnect.
@@ -379,7 +379,7 @@ export class MqttClientConnection extends BufferedEventEmitter {
      *
      * @event
      */
-    static CONNECTION_SUCCESS = 'connection_success';
+    static CONNECTION_SUCCESS : 'connection_success' = 'connection_success';
 
     /**
      * Emitted on an unsuccessful connect and reconnect.
@@ -387,14 +387,14 @@ export class MqttClientConnection extends BufferedEventEmitter {
      *
      * @event
      */
-    static CONNECTION_FAILURE = 'connection_failure';
+    static CONNECTION_FAILURE : 'connection_failure' = 'connection_failure';
 
     /**
      * Emitted when the MQTT connection was disconnected and shutdown successfully.
      *
      * @event
      */
-    static CLOSED = 'closed'
+    static CLOSED : 'closed' = 'closed'
 
     on(event: 'connect', listener: MqttConnectionConnected): this;
 

--- a/lib/browser/mqtt5.ts
+++ b/lib/browser/mqtt5.ts
@@ -408,7 +408,7 @@ export class Mqtt5Client extends BufferedEventEmitter implements mqtt5.IMqtt5Cli
      *
      * @event
      */
-    static ERROR : string = 'error';
+    static ERROR : 'error' = 'error';
 
     /**
      * Event emitted when the client encounters a transient error event that will not disrupt promises based on
@@ -419,7 +419,7 @@ export class Mqtt5Client extends BufferedEventEmitter implements mqtt5.IMqtt5Cli
      * @event
      * @group Browser-only
      */
-    static INFO : string = 'info';
+    static INFO : 'info' = 'info';
 
     /**
      * Event emitted when an MQTT PUBLISH packet is received by the client.
@@ -428,7 +428,7 @@ export class Mqtt5Client extends BufferedEventEmitter implements mqtt5.IMqtt5Cli
      *
      * @event
      */
-    static MESSAGE_RECEIVED : string = 'messageReceived';
+    static MESSAGE_RECEIVED : 'messageReceived' = 'messageReceived';
 
     /**
      * Event emitted when the client begins a connection attempt.
@@ -437,7 +437,7 @@ export class Mqtt5Client extends BufferedEventEmitter implements mqtt5.IMqtt5Cli
      *
      * @event
      */
-    static ATTEMPTING_CONNECT : string = 'attemptingConnect';
+    static ATTEMPTING_CONNECT : 'attemptingConnect' = 'attemptingConnect';
 
     /**
      * Event emitted when the client successfully establishes an MQTT connection.  Only emitted after
@@ -447,7 +447,7 @@ export class Mqtt5Client extends BufferedEventEmitter implements mqtt5.IMqtt5Cli
      *
      * @event
      */
-    static CONNECTION_SUCCESS : string = 'connectionSuccess';
+    static CONNECTION_SUCCESS : 'connectionSuccess' = 'connectionSuccess';
 
     /**
      * Event emitted when the client fails to establish an MQTT connection.  Only emitted after
@@ -457,7 +457,7 @@ export class Mqtt5Client extends BufferedEventEmitter implements mqtt5.IMqtt5Cli
      *
      * @event
      */
-    static CONNECTION_FAILURE : string = 'connectionFailure';
+    static CONNECTION_FAILURE : 'connectionFailure' = 'connectionFailure';
 
     /**
      * Event emitted when the client's current connection is closed for any reason.  Only emitted after
@@ -467,7 +467,7 @@ export class Mqtt5Client extends BufferedEventEmitter implements mqtt5.IMqtt5Cli
      *
      * @event
      */
-    static DISCONNECTION : string = 'disconnection';
+    static DISCONNECTION : 'disconnection' = 'disconnection';
 
     /**
      * Event emitted when the client finishes shutdown as a result of the user invoking {@link stop}.
@@ -476,7 +476,7 @@ export class Mqtt5Client extends BufferedEventEmitter implements mqtt5.IMqtt5Cli
      *
      * @event
      */
-    static STOPPED : string = 'stopped';
+    static STOPPED : 'stopped' = 'stopped';
 
     /**
      * Registers a listener for the client's {@link ERROR error} event.  An {@link ERROR error} event is emitted when

--- a/lib/browser/mqtt_internal/client.ts
+++ b/lib/browser/mqtt_internal/client.ts
@@ -648,7 +648,7 @@ export class Client extends BufferedEventEmitter {
      *
      * @event
      */
-    static CONNECTING : string = 'connecting';
+    static CONNECTING : 'connecting' = 'connecting';
 
     /**
      * Event emitted when the client has successfully connected to the remote broker
@@ -657,7 +657,7 @@ export class Client extends BufferedEventEmitter {
      *
      * @event
      */
-    static CONNECTION_SUCCESS : string = 'connectionSuccess';
+    static CONNECTION_SUCCESS : 'connectionSuccess' = 'connectionSuccess';
 
     /**
      * Event emitted when the client has failed to connect to the remote broker
@@ -666,7 +666,7 @@ export class Client extends BufferedEventEmitter {
      *
      * @event
      */
-    static CONNECTION_FAILURE : string = 'connectionFailure';
+    static CONNECTION_FAILURE : 'connectionFailure' = 'connectionFailure';
 
     /**
      * Event emitted when the client's connection has been closed
@@ -675,7 +675,7 @@ export class Client extends BufferedEventEmitter {
      *
      * @event
      */
-    static DISCONNECTION : string = 'disconnection';
+    static DISCONNECTION : 'disconnection' = 'disconnection';
 
     /**
      * Event emitted when the client enters the stopped state
@@ -684,7 +684,7 @@ export class Client extends BufferedEventEmitter {
      *
      * @event
      */
-    static STOPPED : string = 'stopped';
+    static STOPPED : 'stopped' = 'stopped';
 
     /**
      * Event emitted when the client receives a publish message from the broker
@@ -693,7 +693,7 @@ export class Client extends BufferedEventEmitter {
      *
      * @event
      */
-    static PUBLISH_RECEIVED : string = 'publishReceived';
+    static PUBLISH_RECEIVED : 'publishReceived' = 'publishReceived';
 
     /**
      * Registers a listener for the client's {@link ConnectingEvent} event.  A

--- a/lib/browser/mqtt_internal/protocol.ts
+++ b/lib/browser/mqtt_internal/protocol.ts
@@ -886,7 +886,7 @@ export class ProtocolState extends BufferedEventEmitter implements IProtocolStat
      *
      * @event
      */
-    static HALTED : string = 'halted';
+    static HALTED : 'halted' = 'halted';
 
     /**
      * Event emitted when a disconnect packet is received
@@ -895,7 +895,7 @@ export class ProtocolState extends BufferedEventEmitter implements IProtocolStat
      *
      * @event
      */
-    static DISCONNECT_RECEIVED : string = 'disconnectReceived';
+    static DISCONNECT_RECEIVED : 'disconnectReceived' = 'disconnectReceived';
 
     /**
      * Event emitted when a publish packet is received
@@ -904,7 +904,7 @@ export class ProtocolState extends BufferedEventEmitter implements IProtocolStat
      *
      * @event
      */
-    static PUBLISH_RECEIVED : string = 'publishReceived';
+    static PUBLISH_RECEIVED : 'publishReceived' = 'publishReceived';
 
     /**
      * Event emitted when a connack packet is received
@@ -913,7 +913,7 @@ export class ProtocolState extends BufferedEventEmitter implements IProtocolStat
      *
      * @event
      */
-    static CONNACK_RECEIVED : string = 'connackReceived';
+    static CONNACK_RECEIVED : 'connackReceived' = 'connackReceived';
 
     /**
      * Registers a listener for the client's {@link HALTED} {@link HaltedEvent} event.  A

--- a/lib/browser/mqtt_request_response.ts
+++ b/lib/browser/mqtt_request_response.ts
@@ -184,7 +184,7 @@ export class StreamingOperationBase extends BufferedEventEmitter implements mqtt
      *
      * @event
      */
-    static SUBSCRIPTION_STATUS : string = 'subscriptionStatus';
+    static SUBSCRIPTION_STATUS : 'subscriptionStatus' = 'subscriptionStatus';
 
     /**
      * Event emitted when a stream message is received
@@ -193,7 +193,7 @@ export class StreamingOperationBase extends BufferedEventEmitter implements mqtt
      *
      * @event
      */
-    static INCOMING_PUBLISH : string = 'incomingPublish';
+    static INCOMING_PUBLISH : 'incomingPublish' = 'incomingPublish';
 
     on(event: 'subscriptionStatus', listener: mqtt_request_response.SubscriptionStatusListener): this;
 

--- a/lib/browser/mqtt_request_response/protocol_adapter.ts
+++ b/lib/browser/mqtt_request_response/protocol_adapter.ts
@@ -454,15 +454,15 @@ export class ProtocolClientAdapter extends BufferedEventEmitter {
         return this.connectionState;
     }
 
-    static PUBLISH_COMPLETION : string = 'publishCompletion';
+    static PUBLISH_COMPLETION : 'publishCompletion' = 'publishCompletion';
 
-    static SUBSCRIBE_COMPLETION : string = 'subscribeCompletion';
+    static SUBSCRIBE_COMPLETION : 'subscribeCompletion' = 'subscribeCompletion';
 
-    static UNSUBSCRIBE_COMPLETION : string = 'unsubscribeCompletion';
+    static UNSUBSCRIBE_COMPLETION : 'unsubscribeCompletion' = 'unsubscribeCompletion';
 
-    static CONNECTION_STATUS : string = 'connectionStatus';
+    static CONNECTION_STATUS : 'connectionStatus' = 'connectionStatus';
 
-    static INCOMING_PUBLISH : string = 'incomingPublish';
+    static INCOMING_PUBLISH : 'incomingPublish' = 'incomingPublish';
 
     on(event: 'publishCompletion', listener: PublishCompletionEventListener): this;
 

--- a/lib/browser/mqtt_request_response/subscription_manager.ts
+++ b/lib/browser/mqtt_request_response/subscription_manager.ts
@@ -348,14 +348,14 @@ export class SubscriptionManager extends BufferedEventEmitter {
         }
     }
 
-    static SUBSCRIBE_SUCCESS : string = 'subscribeSuccess';
-    static SUBSCRIBE_FAILURE : string = 'subscribeFailure';
-    static SUBSCRIPTION_ENDED : string = 'subscriptionEnded';
-    static STREAMING_SUBSCRIPTION_ESTABLISHED : string = "streamingSubscriptionEstablished";
-    static STREAMING_SUBSCRIPTION_LOST : string = "streamingSubscriptionLost";
-    static STREAMING_SUBSCRIPTION_HALTED : string = "streamingSubscriptionHalted";
-    static SUBSCRIPTION_ORPHANED : string = "subscriptionOrphaned";
-    static UNSUBSCRIBE_COMPLETE : string = "unsubscribeComplete";
+    static SUBSCRIBE_SUCCESS : 'subscribeSuccess' = 'subscribeSuccess';
+    static SUBSCRIBE_FAILURE : 'subscribeFailure' = 'subscribeFailure';
+    static SUBSCRIPTION_ENDED : 'subscriptionEnded' = 'subscriptionEnded';
+    static STREAMING_SUBSCRIPTION_ESTABLISHED : "streamingSubscriptionEstablished" = "streamingSubscriptionEstablished";
+    static STREAMING_SUBSCRIPTION_LOST : "streamingSubscriptionLost" = "streamingSubscriptionLost";
+    static STREAMING_SUBSCRIPTION_HALTED : "streamingSubscriptionHalted" = "streamingSubscriptionHalted";
+    static SUBSCRIPTION_ORPHANED : "subscriptionOrphaned" = "subscriptionOrphaned";
+    static UNSUBSCRIBE_COMPLETE : "unsubscribeComplete" = "unsubscribeComplete";
 
     on(event: 'subscribeSuccess', listener: SubscribeSuccessEventListener): this;
     on(event: 'subscribeFailure', listener: SubscribeFailureEventListener): this;
@@ -650,4 +650,3 @@ export class SubscriptionManager extends BufferedEventEmitter {
     }
 
 }
-

--- a/lib/native/eventstream.ts
+++ b/lib/native/eventstream.ts
@@ -798,7 +798,7 @@ export class ClientConnection extends NativeResourceMixin(BufferedEventEmitter) 
      *
      * @event
      */
-    static DISCONNECTION : string = 'disconnection';
+    static DISCONNECTION : 'disconnection' = 'disconnection';
 
     /**
      * Event emitted when a protocol message is received from the remote endpoint
@@ -807,7 +807,7 @@ export class ClientConnection extends NativeResourceMixin(BufferedEventEmitter) 
      *
      * @event
      */
-    static PROTOCOL_MESSAGE : string = 'protocolMessage';
+    static PROTOCOL_MESSAGE : 'protocolMessage' = 'protocolMessage';
 
     on(event: 'disconnection', listener: DisconnectionListener): this;
 
@@ -1053,7 +1053,7 @@ export class ClientStream extends NativeResourceMixin(BufferedEventEmitter) {
      *
      * @event
      */
-    static ENDED : string = 'ended';
+    static ENDED : 'ended' = 'ended';
 
     /**
      * Event emitted when a stream message is received from the remote endpoint
@@ -1062,7 +1062,7 @@ export class ClientStream extends NativeResourceMixin(BufferedEventEmitter) {
      *
      * @event
      */
-    static MESSAGE : string = 'message';
+    static MESSAGE : 'message' = 'message';
 
     on(event: 'ended', listener: StreamEndedListener): this;
 

--- a/lib/native/http.ts
+++ b/lib/native/http.ts
@@ -86,21 +86,21 @@ export class HttpConnection extends NativeResourceMixin(BufferedEventEmitter) im
      *
      * @event
      */
-    static CONNECT = 'connect';
+    static CONNECT : 'connect' = 'connect';
 
     /**
      * Emitted when an error occurs on the connection
      *
      * @event
      */
-    static ERROR = 'error';
+    static ERROR : 'error' = 'error';
 
     /**
      * Emitted when the connection has completed
      *
      * @event
      */
-    static CLOSE = 'close';
+    static CLOSE : 'close' = 'close';
 
     on(event: 'connect', listener: HttpClientConnectionConnected): this;
 
@@ -399,35 +399,35 @@ export class HttpClientStream extends HttpStream {
      *
      * @event
      */
-    static RESPONSE = 'response';
+    static RESPONSE : 'response' = 'response';
 
     /**
      * Emitted when http response data is available.
      *
      * @event
      */
-    static DATA = 'data';
+    static DATA : 'data' = 'data';
 
     /**
      * Emitted when an error occurs in stream processing
      *
      * @event
      */
-    static ERROR = 'error';
+    static ERROR : 'error' = 'error';
 
     /**
      * Emitted when the stream has completed
      *
      * @event
      */
-    static END = 'end';
+    static END : 'end' = 'end';
 
     /**
      * Emitted when inline headers are delivered while communicating over H2
      *
      * @event
      */
-    static HEADERS = 'headers';
+    static HEADERS : 'headers' = 'headers';
 
     on(event: 'response', listener: HttpStreamResponse): this;
 

--- a/lib/native/mqtt.ts
+++ b/lib/native/mqtt.ts
@@ -271,14 +271,14 @@ export class MqttClientConnection extends NativeResourceMixin(BufferedEventEmitt
      *
      * @event
      */
-    static CONNECT = 'connect';
+    static CONNECT : 'connect' = 'connect';
 
     /**
      * Emitted when connection has disconnected successfully.
      *
      * @event
      */
-    static DISCONNECT = 'disconnect';
+    static DISCONNECT : 'disconnect' = 'disconnect';
 
     /**
      * Emitted when an error occurs.  The error will contain the error
@@ -286,7 +286,7 @@ export class MqttClientConnection extends NativeResourceMixin(BufferedEventEmitt
      *
      * @event
      */
-    static ERROR = 'error';
+    static ERROR : 'error' = 'error';
 
     /**
      * Emitted when the connection is dropped unexpectedly. The error will contain the error
@@ -294,21 +294,21 @@ export class MqttClientConnection extends NativeResourceMixin(BufferedEventEmitt
      *
      * @event
      */
-    static INTERRUPT = 'interrupt';
+    static INTERRUPT : 'interrupt' = 'interrupt';
 
     /**
      * Emitted when the connection reconnects (after an interrupt). Only triggers on connections after the initial one.
      *
      * @event
      */
-    static RESUME = 'resume';
+    static RESUME : 'resume' = 'resume';
 
     /**
      * Emitted when any MQTT publish message arrives.
      *
      * @event
      */
-    static MESSAGE = 'message';
+    static MESSAGE : 'message' = 'message';
 
     /**
      * Emitted on every successful connect and reconnect.
@@ -317,7 +317,7 @@ export class MqttClientConnection extends NativeResourceMixin(BufferedEventEmitt
      *
      * @event
      */
-    static CONNECTION_SUCCESS = 'connection_success';
+    static CONNECTION_SUCCESS : 'connection_success' = 'connection_success';
 
     /**
      * Emitted on an unsuccessful connect and reconnect.
@@ -325,14 +325,14 @@ export class MqttClientConnection extends NativeResourceMixin(BufferedEventEmitt
      *
      * @event
      */
-    static CONNECTION_FAILURE = 'connection_failure';
+    static CONNECTION_FAILURE : 'connection_failure' = 'connection_failure';
 
     /**
      * Emitted when the MQTT connection was disconnected and shutdown successfully.
      *
      * @event
      */
-    static CLOSED = 'closed'
+    static CLOSED : 'closed' = 'closed'
 
     on(event: 'connect', listener: MqttConnectionConnected): this;
 

--- a/lib/native/mqtt5.ts
+++ b/lib/native/mqtt5.ts
@@ -363,7 +363,7 @@ export class Mqtt5Client extends NativeResourceMixin(BufferedEventEmitter) imple
      *
      * @event
      */
-    static ERROR : string = 'error';
+    static ERROR : 'error' = 'error';
 
     /**
      * Event emitted when an MQTT PUBLISH packet is received by the client.
@@ -372,7 +372,7 @@ export class Mqtt5Client extends NativeResourceMixin(BufferedEventEmitter) imple
      *
      * @event
      */
-    static MESSAGE_RECEIVED : string = 'messageReceived';
+    static MESSAGE_RECEIVED : 'messageReceived' = 'messageReceived';
 
     /**
      * Event emitted when the client begins a connection attempt.
@@ -381,7 +381,7 @@ export class Mqtt5Client extends NativeResourceMixin(BufferedEventEmitter) imple
      *
      * @event
      */
-    static ATTEMPTING_CONNECT : string = 'attemptingConnect';
+    static ATTEMPTING_CONNECT : 'attemptingConnect' = 'attemptingConnect';
 
     /**
      * Event emitted when the client successfully establishes an MQTT connection.  Only emitted after
@@ -391,7 +391,7 @@ export class Mqtt5Client extends NativeResourceMixin(BufferedEventEmitter) imple
      *
      * @event
      */
-    static CONNECTION_SUCCESS : string = 'connectionSuccess';
+    static CONNECTION_SUCCESS : 'connectionSuccess' = 'connectionSuccess';
 
     /**
      * Event emitted when the client fails to establish an MQTT connection.  Only emitted after
@@ -401,7 +401,7 @@ export class Mqtt5Client extends NativeResourceMixin(BufferedEventEmitter) imple
      *
      * @event
      */
-    static CONNECTION_FAILURE : string = 'connectionFailure';
+    static CONNECTION_FAILURE : 'connectionFailure' = 'connectionFailure';
 
     /**
      * Event emitted when the client's current connection is closed for any reason.  Only emitted after
@@ -411,7 +411,7 @@ export class Mqtt5Client extends NativeResourceMixin(BufferedEventEmitter) imple
      *
      * @event
      */
-    static DISCONNECTION : string = 'disconnection';
+    static DISCONNECTION : 'disconnection' = 'disconnection';
 
     /**
      * Event emitted when the client finishes shutdown as a result of the user invoking {@link stop}.
@@ -420,7 +420,7 @@ export class Mqtt5Client extends NativeResourceMixin(BufferedEventEmitter) imple
      *
      * @event
      */
-    static STOPPED : string = 'stopped';
+    static STOPPED : 'stopped' = 'stopped';
 
     /**
      * Registers a listener for the client's {@link ERROR error} event.  An {@link ERROR error} event is emitted when

--- a/lib/native/mqtt_request_response.ts
+++ b/lib/native/mqtt_request_response.ts
@@ -93,7 +93,7 @@ export class StreamingOperationBase extends NativeResourceMixin(BufferedEventEmi
      *
      * @event
      */
-    static SUBSCRIPTION_STATUS : string = 'subscriptionStatus';
+    static SUBSCRIPTION_STATUS : 'subscriptionStatus' = 'subscriptionStatus';
 
     /**
      * Event emitted when a stream message is received
@@ -102,7 +102,7 @@ export class StreamingOperationBase extends NativeResourceMixin(BufferedEventEmi
      *
      * @event
      */
-    static INCOMING_PUBLISH : string = 'incomingPublish';
+    static INCOMING_PUBLISH : 'incomingPublish' = 'incomingPublish';
 
     on(event: 'subscriptionStatus', listener: mqtt_request_response.SubscriptionStatusListener): this;
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Customers PR to fix the typescript error: ` Argument of type 'string' is not assignable to parameter of type`
Preserve literal types for event name constants: #737

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
